### PR TITLE
[OPS-5828][OPS-5687] Path patch.inc (even for redis)

### DIFF
--- a/html/includes/common.inc
+++ b/html/includes/common.inc
@@ -2320,6 +2320,7 @@ function url($path = NULL, array $options = array()) {
   }
   elseif (!empty($path) && !$options['alias']) {
     $language = isset($options['language']) && isset($options['language']->language) ? $options['language']->language : '';
+    require_once DRUPAL_ROOT . '/' . variable_get('path_inc', 'includes/path.inc');
     $alias = drupal_get_path_alias($original_path, $language);
     if ($alias != $original_path) {
       // Strip leading slashes from internal path aliases to prevent them

--- a/html/sites/all/modules/contrib/redis/redis.path.inc
+++ b/html/sites/all/modules/contrib/redis/redis.path.inc
@@ -235,6 +235,10 @@ function drupal_cache_system_paths() {
  *   found.
  */
 function drupal_get_path_alias($path = NULL, $path_language = NULL) {
+  // Patch to enable path_alias_xt.module to operate.
+  if (module_exists('path_alias_xt')) {
+    return path_alias_xt_get_path_alias($path, $path_language);
+  }
   // If no path is specified, use the current page's path.
   if ($path == NULL) {
     $path = $_GET['q'];


### PR DESCRIPTION
Redis module has its own path.inc which should be used *everywhere* by
core. However, our core path.inc is patched by path_alias_xt module and
this means that on order to get reliable operation, we *also* need to
patch the redis-provided path.inc version with the path_alias_xt fix.

The alternative is to install PECL runkit, but that has security
implications we would rather not deal with.