### PR TITLE
[HRINFO-977] update core to 7.69

### DIFF
--- a/html/.htaccess
+++ b/html/.htaccess
@@ -3,7 +3,7 @@
 #
 
 # Protect files and directories from prying eyes.
-<FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
+<FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
   <IfModule mod_authz_core.c>
     Require all denied
   </IfModule>

--- a/html/CHANGELOG.txt
+++ b/html/CHANGELOG.txt
@@ -1,6 +1,30 @@
 Drupal 7.xx, xxxx-xx-xx (development version)
 -----------------------
 
+Drupal 7.69, 2019-12-18
+-----------------------
+- Fixed security issues:
+   - SA-CORE-2019-012
+
+Drupal 7.68, 2019-12-04
+-----------------------
+- Fixed: Hide toolbar when printing
+- Fixed: Settings returned via ajax are not run through hook_js_alter()
+- Fixed: Use drupal_http_build_query() in drupal_http_request()
+- Fixed: DrupalRequestSanitizer not found fatal error when bootstrap phase order is changed
+- Fixed: Block web.config in .htaccess (and vice-versa)
+- Fixed: Create "scripts" element to align rendering workflow to how "styles" are handled
+- PHP 7.3: Fixed 'Cannot change session id when session is active'
+- PHP 7.1: Fixed 'A non-numeric value encountered in theme_pager()'
+- PHP 7.x: Fixed file.inc generated .htaccess does not cover PHP 7
+- PHP 5.3: Fixed check_plain() 'Invalid multibyte sequence in argument' test failures
+- Fixed: Allow passing data as array to drupal_http_request()
+- Fixed: Skip module_invoke/module_hook in calling hook_watchdog (excessive function_exist)
+- Fixed: HTTP status 200 returned for 'Additional uncaught exception thrown while handling exception'
+- Fixed: theme_table() should take an optional footer variable and produce <tfoot>
+- Fixed: 'uasort() expects parameter 1 to be array, null given in node_view_multiple()'
+- [regression] Fix default.settings.php permission
+
 Drupal 7.67, 2019-05-08
 -----------------------
 - Fixed security issues:

--- a/html/MAINTAINERS.txt
+++ b/html/MAINTAINERS.txt
@@ -11,11 +11,8 @@ The Drupal Core branch maintainers oversee the development of Drupal as a whole.
 The branch maintainers for Drupal 7 are:
 
 - Dries Buytaert 'dries' https://www.drupal.org/u/dries
-- Angela Byron 'webchick' https://www.drupal.org/u/webchick
 - Fabian Franz 'Fabianx' https://www.drupal.org/u/fabianx
-- David Rothstein 'David_Rothstein' https://www.drupal.org/u/david_rothstein
-- Stefan Ruijsenaars 'stefan.r' https://www.drupal.org/u/stefanr-0
-- (provisional) Pol Dellaiera 'Pol' https://www.drupal.org/u/pol
+- (provisional) Drew Webber 'mcdruid' https://www.drupal.org/u/mcdruid
 
 
 Component maintainers

--- a/html/includes/ajax.inc
+++ b/html/includes/ajax.inc
@@ -294,6 +294,7 @@ function ajax_render($commands = array()) {
 
   // Now add a command to merge changes and additions to Drupal.settings.
   $scripts = drupal_add_js();
+  drupal_alter('js', $scripts);
   if (!empty($scripts['settings'])) {
     $settings = $scripts['settings'];
     array_unshift($commands, ajax_command_settings(drupal_array_merge_deep_array($settings['data']), TRUE));

--- a/html/includes/bootstrap.inc
+++ b/html/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.67');
+define('VERSION', '7.69');
 
 /**
  * Core API compatibility.
@@ -1998,7 +1998,7 @@ function watchdog($type, $message, $variables = array(), $severity = WATCHDOG_NO
 
   // It is possible that the error handling will itself trigger an error. In that case, we could
   // end up in an infinite loop. To avoid that, we implement a simple static semaphore.
-  if (!$in_error_state && function_exists('module_implements')) {
+  if (!$in_error_state && function_exists('module_invoke_all')) {
     $in_error_state = TRUE;
 
     // The user object may not exist in all conditions, so 0 is substituted if needed.
@@ -2021,9 +2021,7 @@ function watchdog($type, $message, $variables = array(), $severity = WATCHDOG_NO
     );
 
     // Call the logging hooks to log/process the message
-    foreach (module_implements('watchdog') as $module) {
-      module_invoke($module, 'watchdog', $log_entry);
-    }
+    module_invoke_all('watchdog', $log_entry);
 
     // It is critical that the semaphore is only cleared here, in the parent
     // watchdog() call (not outside the loop), to prevent recursive execution.
@@ -2518,6 +2516,7 @@ function drupal_bootstrap($phase = NULL, $new_phase = TRUE) {
 
       switch ($current_phase) {
         case DRUPAL_BOOTSTRAP_CONFIGURATION:
+          require_once DRUPAL_ROOT . '/includes/request-sanitizer.inc';
           _drupal_bootstrap_configuration();
           break;
 
@@ -2622,6 +2621,10 @@ function _drupal_exception_handler($exception) {
     _drupal_log_error(_drupal_decode_exception($exception), TRUE);
   }
   catch (Exception $exception2) {
+    // Add a 500 status code in case an exception was thrown before the 500
+    // status could be set (e.g. while loading a maintenance theme from cache).
+    drupal_add_http_header('Status', '500 Internal Server Error');
+
     // Another uncaught exception was thrown while handling the first one.
     // If we are displaying errors, then do so with no possibility of a further uncaught exception being thrown.
     if (error_displayable()) {
@@ -2647,7 +2650,6 @@ function _drupal_bootstrap_configuration() {
   drupal_settings_initialize();
 
   // Sanitize unsafe keys from the request.
-  require_once DRUPAL_ROOT . '/includes/request-sanitizer.inc';
   DrupalRequestSanitizer::sanitize();
 }
 

--- a/html/includes/common.inc
+++ b/html/includes/common.inc
@@ -760,9 +760,10 @@ function drupal_access_denied() {
  *   (optional) An array that can have one or more of the following elements:
  *   - headers: An array containing request headers to send as name/value pairs.
  *   - method: A string containing the request method. Defaults to 'GET'.
- *   - data: A string containing the request body, formatted as
- *     'param=value&param=value&...'; to generate this, use http_build_query().
- *     Defaults to NULL.
+ *   - data: An array containing the values for the request body or a string
+ *     containing the request body, formatted as
+ *     'param=value&param=value&...'; to generate this, use
+ *     drupal_http_build_query(). Defaults to NULL.
  *   - max_redirects: An integer representing how many times a redirect
  *     may be followed. Defaults to 3.
  *   - timeout: A float representing the maximum number of seconds the function
@@ -788,7 +789,7 @@ function drupal_access_denied() {
  *     easy access the array keys are returned in lower case.
  *   - data: A string containing the response body that was received.
  *
- * @see http_build_query()
+ * @see drupal_http_build_query()
  */
 function drupal_http_request($url, array $options = array()) {
   // Allow an alternate HTTP client library to replace Drupal's default
@@ -928,6 +929,11 @@ function drupal_http_request($url, array $options = array()) {
   $path = isset($uri['path']) ? $uri['path'] : '/';
   if (isset($uri['query'])) {
     $path .= '?' . $uri['query'];
+  }
+
+  // Convert array $options['data'] to query string.
+  if (is_array($options['data'])) {
+    $options['data'] = drupal_http_build_query($options['data']);
   }
 
   // Only add Content-Length if we actually have any content or if it is a POST
@@ -4442,12 +4448,54 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
     }
   }
 
-  $output = '';
-  // The index counter is used to keep aggregated and non-aggregated files in
-  // order by weight.
-  $index = 1;
-  $processed = array();
-  $files = array();
+  // Sort the JavaScript so that it appears in the correct order.
+  uasort($items, 'drupal_sort_css_js');
+
+  // Provide the page with information about the individual JavaScript files
+  // used, information not otherwise available when aggregation is enabled.
+  $setting['ajaxPageState']['js'] = array_fill_keys(array_keys($items), 1);
+  unset($setting['ajaxPageState']['js']['settings']);
+  drupal_add_js($setting, 'setting');
+
+  // If we're outputting the header scope, then this might be the final time
+  // that drupal_get_js() is running, so add the setting to this output as well
+  // as to the drupal_add_js() cache. If $items['settings'] doesn't exist, it's
+  // because drupal_get_js() was intentionally passed a $javascript argument
+  // stripped off settings, potentially in order to override how settings get
+  // output, so in this case, do not add the setting to this output.
+  if ($scope == 'header' && isset($items['settings'])) {
+    $items['settings']['data'][] = $setting;
+  }
+
+  $elements = array(
+    '#type' => 'scripts',
+    '#items' => $items,
+  );
+
+  return drupal_render($elements);
+}
+
+/**
+ * The #pre_render callback for the "scripts" element.
+ *
+ * This callback adds elements needed for <script> tags to be rendered.
+ *
+ * @param array $elements
+ *   A render array containing:
+ *   - '#items': The JS items as returned by drupal_add_js() and altered by
+ *     drupal_get_js().
+ *
+ * @return array
+ *   The $elements variable passed as argument with two more children keys:
+ *     - "scripts": contains the Javascript items
+ *     - "settings": contains the Javascript settings items.
+ *   If those keys are already existing, then the items will be appended and
+ *   their keys will be preserved.
+ *
+ * @see drupal_get_js()
+ * @see drupal_add_js()
+ */
+function drupal_pre_render_scripts(array $elements) {
   $preprocess_js = (variable_get('preprocess_js', FALSE) && (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'update'));
 
   // A dummy query-string is added to filenames, to gain control over
@@ -4468,34 +4516,29 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
   // third-party code might require the use of a different query string.
   $js_version_string = variable_get('drupal_js_version_query_string', 'v=');
 
-  // Sort the JavaScript so that it appears in the correct order.
-  uasort($items, 'drupal_sort_css_js');
+  $files = array();
 
-  // Provide the page with information about the individual JavaScript files
-  // used, information not otherwise available when aggregation is enabled.
-  $setting['ajaxPageState']['js'] = array_fill_keys(array_keys($items), 1);
-  unset($setting['ajaxPageState']['js']['settings']);
-  drupal_add_js($setting, 'setting');
+  $scripts = isset($elements['scripts']) ? $elements['scripts'] : array();
+  $scripts += array('#weight' => 0);
 
-  // If we're outputting the header scope, then this might be the final time
-  // that drupal_get_js() is running, so add the setting to this output as well
-  // as to the drupal_add_js() cache. If $items['settings'] doesn't exist, it's
-  // because drupal_get_js() was intentionally passed a $javascript argument
-  // stripped off settings, potentially in order to override how settings get
-  // output, so in this case, do not add the setting to this output.
-  if ($scope == 'header' && isset($items['settings'])) {
-    $items['settings']['data'][] = $setting;
-  }
+  $settings = isset($elements['settings']) ? $elements['settings'] : array();
+  $settings += array('#weight' => $scripts['#weight'] + 10);
+
+  // The index counter is used to keep aggregated and non-aggregated files in
+  // order by weight. Use existing scripts count as a starting point.
+  $index = count(element_children($scripts)) + 1;
 
   // Loop through the JavaScript to construct the rendered output.
   $element = array(
+    '#type' => 'html_tag',
     '#tag' => 'script',
     '#value' => '',
     '#attributes' => array(
       'type' => 'text/javascript',
     ),
   );
-  foreach ($items as $item) {
+
+  foreach ($elements['#items'] as $item) {
     $query_string =  empty($item['version']) ? $default_query_string : $js_version_string . $item['version'];
 
     switch ($item['type']) {
@@ -4504,7 +4547,7 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
         $js_element['#value_prefix'] = $embed_prefix;
         $js_element['#value'] = 'jQuery.extend(Drupal.settings, ' . drupal_json_encode(drupal_array_merge_deep_array($item['data'])) . ");";
         $js_element['#value_suffix'] = $embed_suffix;
-        $output .= theme('html_tag', array('element' => $js_element));
+        $settings[] = $js_element;
         break;
 
       case 'inline':
@@ -4515,7 +4558,7 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
         $js_element['#value_prefix'] = $embed_prefix;
         $js_element['#value'] = $item['data'];
         $js_element['#value_suffix'] = $embed_suffix;
-        $processed[$index++] = theme('html_tag', array('element' => $js_element));
+        $scripts[$index++] = $js_element;
         break;
 
       case 'file':
@@ -4526,7 +4569,7 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
           }
           $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
           $js_element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
-          $processed[$index++] = theme('html_tag', array('element' => $js_element));
+          $scripts[$index++] = $js_element;
         }
         else {
           // By increasing the index for each aggregated file, we maintain
@@ -4537,7 +4580,7 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
           // leading to better front-end performance of a website as a whole.
           // See drupal_add_js() for details.
           $key = 'aggregate_' . $item['group'] . '_' . $item['every_page'] . '_' . $index;
-          $processed[$key] = '';
+          $scripts[$key] = '';
           $files[$key][$item['data']] = $item;
         }
         break;
@@ -4549,7 +4592,7 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
           $js_element['#attributes']['defer'] = 'defer';
         }
         $js_element['#attributes']['src'] = $item['data'];
-        $processed[$index++] = theme('html_tag', array('element' => $js_element));
+        $scripts[$index++] = $js_element;
         break;
     }
   }
@@ -4564,14 +4607,18 @@ function drupal_get_js($scope = 'header', $javascript = NULL, $skip_alter = FALS
         $preprocess_file = file_create_url($uri);
         $js_element = $element;
         $js_element['#attributes']['src'] = $preprocess_file;
-        $processed[$key] = theme('html_tag', array('element' => $js_element));
+        $scripts[$key] = $js_element;
       }
     }
   }
 
-  // Keep the order of JS files consistent as some are preprocessed and others are not.
-  // Make sure any inline or JS setting variables appear last after libraries have loaded.
-  return implode('', $processed) . $output;
+  // Keep the order of JS files consistent as some are preprocessed and others
+  // are not. Make sure any inline or JS setting variables appear last after
+  // libraries have loaded.
+  $element['scripts'] = $scripts;
+  $element['settings'] = $settings;
+
+  return $element;
 }
 
 /**
@@ -6953,7 +7000,16 @@ function drupal_common_theme() {
       'variables' => array(),
     ),
     'table' => array(
-      'variables' => array('header' => NULL, 'rows' => NULL, 'attributes' => array(), 'caption' => NULL, 'colgroups' => array(), 'sticky' => TRUE, 'empty' => ''),
+      'variables' => array(
+        'header' => NULL,
+        'footer' => NULL,
+        'rows' => NULL,
+        'attributes' => array(),
+        'caption' => NULL,
+        'colgroups' => array(),
+        'sticky' => TRUE,
+        'empty' => '',
+      ),
     ),
     'tablesort_indicator' => array(
       'variables' => array('style' => NULL),

--- a/html/includes/file.inc
+++ b/html/includes/file.inc
@@ -532,6 +532,9 @@ SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
 <IfModule mod_php5.c>
   php_flag engine off
 </IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
 EOF;
 
   if ($private) {

--- a/html/includes/pager.inc
+++ b/html/includes/pager.inc
@@ -321,7 +321,7 @@ function theme_pager($variables) {
   $tags = $variables['tags'];
   $element = $variables['element'];
   $parameters = $variables['parameters'];
-  $quantity = $variables['quantity'];
+  $quantity = empty($variables['quantity']) ? 0 : $variables['quantity'];
   global $pager_page_array, $pager_total;
 
   // Calculate various markers within this pager piece:

--- a/html/includes/session.inc
+++ b/html/includes/session.inc
@@ -371,8 +371,11 @@ function drupal_session_regenerate() {
 
   if (drupal_session_started()) {
     $old_session_id = session_id();
+    _drupal_session_regenerate_existing();
   }
-  session_id(drupal_random_key());
+  else {
+    session_id(drupal_random_key());
+  }
 
   if (isset($old_session_id)) {
     $params = session_get_cookie_params();
@@ -410,6 +413,26 @@ function drupal_session_regenerate() {
     $user = $account;
   }
   date_default_timezone_set(drupal_get_user_timezone());
+}
+
+/**
+ * Regenerates an existing session.
+ */
+function _drupal_session_regenerate_existing() {
+  global $user;
+  // Preserve existing settings for the saving of sessions.
+  $original_save_session_status = drupal_save_session();
+  // Turn off saving of sessions.
+  drupal_save_session(FALSE);
+  session_write_close();
+  drupal_session_started(FALSE);
+  // Preserve the user object, as starting a new session will reset it.
+  $original_user = $user;
+  session_id(drupal_random_key());
+  drupal_session_start();
+  $user = $original_user;
+  // Restore the original settings for the saving of sessions.
+  drupal_save_session($original_save_session_status);
 }
 
 /**

--- a/html/includes/theme.inc
+++ b/html/includes/theme.inc
@@ -1911,7 +1911,7 @@ function theme_breadcrumb($variables) {
 /**
  * Returns HTML for a table.
  *
- * @param $variables
+ * @param array $variables
  *   An associative array containing:
  *   - header: An array containing the table headers. Each element of the array
  *     can be either a localized string or an associative array with the
@@ -1948,6 +1948,11 @@ function theme_breadcrumb($variables) {
  *       )
  *     );
  *     @endcode
+ *   - footer: An array of table rows which will be printed within a <tfoot>
+ *     tag, in the same format as the rows element (see above).
+ *     The structure is the same the one defined for the "rows" key except
+ *     that the no_striping boolean has no effect, there is no rows striping
+ *     for the table footer.
  *   - attributes: An array of HTML attributes to apply to the table tag.
  *   - caption: A localized string to use for the <caption> tag.
  *   - colgroups: An array of column groups. Each element of the array can be
@@ -1984,8 +1989,11 @@ function theme_breadcrumb($variables) {
  *   - sticky: Use a "sticky" table header.
  *   - empty: The message to display in an extra row if table does not have any
  *     rows.
+ *
+ * @return string
+ *   The HTML output.
  */
-function theme_table($variables) {
+function theme_table(array $variables) {
   $header = $variables['header'];
   $rows = $variables['rows'];
   $attributes = $variables['attributes'];
@@ -2049,17 +2057,27 @@ function theme_table($variables) {
     if (!empty($header)) {
       foreach ($header as $header_cell) {
         if (is_array($header_cell)) {
-          $header_count += isset($header_cell['colspan']) ? $header_cell['colspan'] : 1;
+          $header_count += isset($header_cell['colspan']) ?
+            $header_cell['colspan'] : 1;
         }
         else {
           $header_count++;
         }
       }
     }
-    $rows[] = array(array('data' => $empty, 'colspan' => $header_count, 'class' => array('empty', 'message')));
+    $rows[] = array(
+      array(
+        'data' => $empty,
+        'colspan' => $header_count,
+        'class' => array(
+          'empty',
+          'message'
+        ),
+      ),
+    );
   }
 
-  // Format the table header:
+  // Format the table header.
   if (!empty($header)) {
     $ts = tablesort_init($header);
     // HTML requires that the thead tag has tr tags in it followed by tbody
@@ -2069,23 +2087,39 @@ function theme_table($variables) {
       $cell = tablesort_header($cell, $header, $ts);
       $output .= _theme_table_cell($cell, TRUE);
     }
-    // Using ternary operator to close the tags based on whether or not there are rows
+    // Using ternary operator to close the tags based on whether
+    // or not there are rows.
     $output .= (!empty($rows) ? " </tr></thead>\n" : "</tr>\n");
   }
   else {
     $ts = array();
   }
 
-  // Format the table rows:
+  // Format the table and footer rows.
+  $sections = array();
+
   if (!empty($rows)) {
-    $output .= "<tbody>\n";
+    $sections['tbody'] = $rows;
+  }
+
+  if (!empty($variables['footer'])) {
+    $sections['tfoot'] = $variables['footer'];
+  }
+
+  // tbody and tfoot have the same structure and are built using the same
+  // procedure.
+  foreach ($sections as $tag => $content) {
+    $output .= "<" . $tag . ">\n";
     $flip = array('even' => 'odd', 'odd' => 'even');
     $class = 'even';
-    foreach ($rows as $number => $row) {
-      // Check if we're dealing with a simple or complex row
+    $default_no_striping = ($tag === 'tfoot');
+
+    foreach ($content as $number => $row) {
+      // Check if we're dealing with a simple or complex row.
       if (isset($row['data'])) {
         $cells = $row['data'];
-        $no_striping = isset($row['no_striping']) ? $row['no_striping'] : FALSE;
+        $no_striping = isset($row['no_striping']) ?
+          $row['no_striping'] : $default_no_striping;
 
         // Set the attributes array and exclude 'data' and 'no_striping'.
         $attributes = $row;
@@ -2095,16 +2129,17 @@ function theme_table($variables) {
       else {
         $cells = $row;
         $attributes = array();
-        $no_striping = FALSE;
+        $no_striping = $default_no_striping;
       }
+
       if (!empty($cells)) {
-        // Add odd/even class
+        // Add odd/even class.
         if (!$no_striping) {
           $class = $flip[$class];
           $attributes['class'][] = $class;
         }
 
-        // Build row
+        // Build row.
         $output .= ' <tr' . drupal_attributes($attributes) . '>';
         $i = 0;
         foreach ($cells as $cell) {
@@ -2114,10 +2149,12 @@ function theme_table($variables) {
         $output .= " </tr>\n";
       }
     }
-    $output .= "</tbody>\n";
+
+    $output .= "</" . $tag . ">\n";
   }
 
   $output .= "</table>\n";
+
   return $output;
 }
 

--- a/html/modules/aggregator/aggregator.info
+++ b/html/modules/aggregator/aggregator.info
@@ -7,7 +7,7 @@ files[] = aggregator.test
 configure = admin/config/services/aggregator/settings
 stylesheets[all][] = aggregator.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/aggregator/tests/aggregator_test.info
+++ b/html/modules/aggregator/tests/aggregator_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/block/block.info
+++ b/html/modules/block/block.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = block.test
 configure = admin/structure/block
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/block/tests/block_test.info
+++ b/html/modules/block/tests/block_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/block/tests/themes/block_test_theme/block_test_theme.info
+++ b/html/modules/block/tests/themes/block_test_theme/block_test_theme.info
@@ -13,7 +13,7 @@ regions[footer] = Footer
 regions[highlighted] = Highlighted
 regions[help] = Help
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/blog/blog.info
+++ b/html/modules/blog/blog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = blog.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/book/book.info
+++ b/html/modules/book/book.info
@@ -7,7 +7,7 @@ files[] = book.test
 configure = admin/content/book/settings
 stylesheets[all][] = book.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/color/color.info
+++ b/html/modules/color/color.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = color.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/comment/comment.info
+++ b/html/modules/comment/comment.info
@@ -9,7 +9,7 @@ files[] = comment.test
 configure = admin/content/comment
 stylesheets[all][] = comment.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/contact/contact.info
+++ b/html/modules/contact/contact.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = contact.test
 configure = admin/structure/contact
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/contextual/contextual.info
+++ b/html/modules/contextual/contextual.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = contextual.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/dashboard/dashboard.info
+++ b/html/modules/dashboard/dashboard.info
@@ -7,7 +7,7 @@ files[] = dashboard.test
 dependencies[] = block
 configure = admin/dashboard/customize
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/dblog/dblog.info
+++ b/html/modules/dblog/dblog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = dblog.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/field.info
+++ b/html/modules/field/field.info
@@ -11,7 +11,7 @@ dependencies[] = field_sql_storage
 required = TRUE
 stylesheets[all][] = theme/field.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/modules/field_sql_storage/field_sql_storage.info
+++ b/html/modules/field/modules/field_sql_storage/field_sql_storage.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = field_sql_storage.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/modules/list/list.info
+++ b/html/modules/field/modules/list/list.info
@@ -7,7 +7,7 @@ dependencies[] = field
 dependencies[] = options
 files[] = tests/list.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/modules/list/tests/list_test.info
+++ b/html/modules/field/modules/list/tests/list_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/modules/number/number.info
+++ b/html/modules/field/modules/number/number.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = number.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/modules/options/options.info
+++ b/html/modules/field/modules/options/options.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = options.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/modules/text/text.info
+++ b/html/modules/field/modules/text/text.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = text.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field/tests/field_test.info
+++ b/html/modules/field/tests/field_test.info
@@ -6,7 +6,7 @@ files[] = field_test.entity.inc
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/field_ui/field_ui.info
+++ b/html/modules/field_ui/field_ui.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = field_ui.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/file/file.info
+++ b/html/modules/file/file.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = tests/file.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/file/tests/file_module_test.info
+++ b/html/modules/file/tests/file_module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/filter/filter.info
+++ b/html/modules/filter/filter.info
@@ -7,7 +7,7 @@ files[] = filter.test
 required = TRUE
 configure = admin/config/content/formats
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/forum/forum.info
+++ b/html/modules/forum/forum.info
@@ -9,7 +9,7 @@ files[] = forum.test
 configure = admin/structure/forum
 stylesheets[all][] = forum.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/help/help.info
+++ b/html/modules/help/help.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = help.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/image/image.info
+++ b/html/modules/image/image.info
@@ -7,7 +7,7 @@ dependencies[] = file
 files[] = image.test
 configure = admin/config/media/image-styles
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/image/tests/image_module_test.info
+++ b/html/modules/image/tests/image_module_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = image_module_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/locale/locale.info
+++ b/html/modules/locale/locale.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = locale.test
 configure = admin/config/regional/language
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/locale/tests/locale_test.info
+++ b/html/modules/locale/tests/locale_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/menu/menu.info
+++ b/html/modules/menu/menu.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = menu.test
 configure = admin/structure/menu
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/node/node.info
+++ b/html/modules/node/node.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/structure/types
 stylesheets[all][] = node.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/node/node.module
+++ b/html/modules/node/node.module
@@ -2668,7 +2668,7 @@ function node_feed($nids = FALSE, $channel = array()) {
  *   An array in the format expected by drupal_render().
  */
 function node_view_multiple($nodes, $view_mode = 'teaser', $weight = 0, $langcode = NULL) {
-  $build = array();
+  $build = array('nodes' => array());
   $entities_by_view_mode = entity_view_mode_prepare('node', $nodes, $view_mode, $langcode);
   foreach ($entities_by_view_mode as $entity_view_mode => $entities) {
     field_attach_prepare_view('node', $entities, $entity_view_mode, $langcode);

--- a/html/modules/node/tests/node_access_test.info
+++ b/html/modules/node/tests/node_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/node/tests/node_test.info
+++ b/html/modules/node/tests/node_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/node/tests/node_test_exception.info
+++ b/html/modules/node/tests/node_test_exception.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/openid/openid.info
+++ b/html/modules/openid/openid.info
@@ -5,7 +5,7 @@ package = Core
 core = 7.x
 files[] = openid.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/openid/tests/openid_test.info
+++ b/html/modules/openid/tests/openid_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = openid
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/overlay/overlay.info
+++ b/html/modules/overlay/overlay.info
@@ -4,7 +4,7 @@ package = Core
 version = VERSION
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/path/path.info
+++ b/html/modules/path/path.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = path.test
 configure = admin/config/search/path
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/php/php.info
+++ b/html/modules/php/php.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = php.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/poll/poll.info
+++ b/html/modules/poll/poll.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = poll.test
 stylesheets[all][] = poll.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/profile/profile.info
+++ b/html/modules/profile/profile.info
@@ -11,7 +11,7 @@ configure = admin/config/people/profile
 ; See user_system_info_alter().
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/rdf/rdf.info
+++ b/html/modules/rdf/rdf.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = rdf.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/rdf/tests/rdf_test.info
+++ b/html/modules/rdf/tests/rdf_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = blog
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/search/search.info
+++ b/html/modules/search/search.info
@@ -8,7 +8,7 @@ files[] = search.test
 configure = admin/config/search/settings
 stylesheets[all][] = search.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/search/tests/search_embedded_form.info
+++ b/html/modules/search/tests/search_embedded_form.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/search/tests/search_extra_type.info
+++ b/html/modules/search/tests/search_extra_type.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/search/tests/search_node_tags.info
+++ b/html/modules/search/tests/search_node_tags.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/shortcut/shortcut.info
+++ b/html/modules/shortcut/shortcut.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = shortcut.test
 configure = admin/config/user-interface/shortcut
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/simpletest.info
+++ b/html/modules/simpletest/simpletest.info
@@ -57,7 +57,7 @@ files[] = tests/upgrade/update.trigger.test
 files[] = tests/upgrade/update.field.test
 files[] = tests/upgrade/update.user.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/actions_loop_test.info
+++ b/html/modules/simpletest/tests/actions_loop_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/ajax_forms_test.info
+++ b/html/modules/simpletest/tests/ajax_forms_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/ajax_test.info
+++ b/html/modules/simpletest/tests/ajax_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/batch_test.info
+++ b/html/modules/simpletest/tests/batch_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/boot_test_1.info
+++ b/html/modules/simpletest/tests/boot_test_1.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/boot_test_2.info
+++ b/html/modules/simpletest/tests/boot_test_2.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/common.test
+++ b/html/modules/simpletest/tests/common.test
@@ -1124,9 +1124,15 @@ class DrupalHTTPRequestTestCase extends DrupalWebTestCase {
     $this->assertEqual($unable_to_parse->code, -1001, 'Returned with "-1001" error code.');
     $this->assertEqual($unable_to_parse->error, 'unable to parse URL', 'Returned with "unable to parse URL" error message.');
 
-    // Fetch page.
-    $result = drupal_http_request(url('node', array('absolute' => TRUE)));
+    // Fetch page and check that the data parameter works with both array and string.
+    $data_array = array($this->randomName() => $this->randomString() . ' "\'');
+    $data_string = drupal_http_build_query($data_array);
+    $result = drupal_http_request(url('node', array('absolute' => TRUE)), array('data' => $data_array));
     $this->assertEqual($result->code, 200, 'Fetched page successfully.');
+    $this->assertTrue(substr($result->request, -strlen($data_string)) === $data_string, 'Request ends with URL-encoded data when drupal_http_request() called using array.');
+    $result = drupal_http_request(url('node', array('absolute' => TRUE)), array('data' => $data_string));
+    $this->assertTrue(substr($result->request, -strlen($data_string)) === $data_string, 'Request ends with URL-encoded data when drupal_http_request() called using string.');
+
     $this->drupalSetContent($result->data);
     $this->assertTitle(t('Welcome to @site-name | @site-name', array('@site-name' => variable_get('site_name', 'Drupal'))), 'Site title matches.');
 

--- a/html/modules/simpletest/tests/common_test.info
+++ b/html/modules/simpletest/tests/common_test.info
@@ -7,7 +7,7 @@ stylesheets[all][] = common_test.css
 stylesheets[print][] = common_test.print.css
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/common_test_cron_helper.info
+++ b/html/modules/simpletest/tests/common_test_cron_helper.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/database_test.info
+++ b/html/modules/simpletest/tests/database_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
+++ b/html/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/html/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/html/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/entity_cache_test.info
+++ b/html/modules/simpletest/tests/entity_cache_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = entity_cache_test_dependency
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/entity_cache_test_dependency.info
+++ b/html/modules/simpletest/tests/entity_cache_test_dependency.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/entity_crud_hook_test.info
+++ b/html/modules/simpletest/tests/entity_crud_hook_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/entity_query_access_test.info
+++ b/html/modules/simpletest/tests/entity_query_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/error_test.info
+++ b/html/modules/simpletest/tests/error_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/file.test
+++ b/html/modules/simpletest/tests/file.test
@@ -963,7 +963,7 @@ class FileDirectoryTest extends FileTestCase {
       $this->fail('Expected exception not thrown');
     }
     catch (RuntimeException $e) {
-      $this->assertEqual("Invalid filename '$filename'", $e->getMessage());
+      $this->assertEqual("Invalid filename '$filename'", $e->getMessage(), 'The invalid filename has been detected and RuntimeException has been thrown.');
     }
 
     // @TODO: Finally we copy a file into a directory several times, to ensure a properly iterating filename suffix.
@@ -1004,7 +1004,7 @@ class FileDirectoryTest extends FileTestCase {
       $this->fail('Expected exception not thrown');
     }
     catch (RuntimeException $e) {
-      $this->assertEqual("Invalid filename 'a\xFFtest\x80€.txt'", $e->getMessage());
+      $this->assertEqual("Invalid filename 'a\xFFtest\x80€.txt'", $e->getMessage(), 'The invalid destination has been detected and RuntimeException has been thrown.');
     }
   }
 

--- a/html/modules/simpletest/tests/file_test.info
+++ b/html/modules/simpletest/tests/file_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = file_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/filter_test.info
+++ b/html/modules/simpletest/tests/filter_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/form_test.info
+++ b/html/modules/simpletest/tests/form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/image_test.info
+++ b/html/modules/simpletest/tests/image_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/menu_test.info
+++ b/html/modules/simpletest/tests/menu_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/module_test.info
+++ b/html/modules/simpletest/tests/module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/pager.test
+++ b/html/modules/simpletest/tests/pager.test
@@ -56,6 +56,22 @@ class PagerFunctionalWebTestCase extends DrupalWebTestCase {
   }
 
   /**
+   * Tests theme_pager() when an empty quantity is passed.
+   */
+  public function testThemePagerQuantityNotSet() {
+    $variables = array(
+      'element' => 0,
+      'parameters' => array(),
+      'quantity' => '',
+      'tags' => '',
+    );
+    pager_default_initialize(100, 10);
+    $rendered_output = theme_pager($variables);
+    $this->assertNotIdentical(stripos($rendered_output, 'next'), FALSE);
+    $this->assertNotIdentical(stripos($rendered_output, 'last'), FALSE);
+  }
+
+  /**
    * Asserts pager items and links.
    *
    * @param int $current_page
@@ -156,4 +172,3 @@ class PagerFunctionalWebTestCase extends DrupalWebTestCase {
     $this->assertTrue(strpos($element['class'], $class) === FALSE, $message);
   }
 }
-

--- a/html/modules/simpletest/tests/path_test.info
+++ b/html/modules/simpletest/tests/path_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/psr_0_test/psr_0_test.info
+++ b/html/modules/simpletest/tests/psr_0_test/psr_0_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/psr_4_test/psr_4_test.info
+++ b/html/modules/simpletest/tests/psr_4_test/psr_4_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/requirements1_test.info
+++ b/html/modules/simpletest/tests/requirements1_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/requirements2_test.info
+++ b/html/modules/simpletest/tests/requirements2_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/session_test.info
+++ b/html/modules/simpletest/tests/session_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/system_dependencies_test.info
+++ b/html/modules/simpletest/tests/system_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = _missing_dependency
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = system_incompatible_core_version_test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/system_incompatible_core_version_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_core_version_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 5.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
@@ -7,7 +7,7 @@ hidden = TRUE
 ; system_incompatible_module_version_test declares version 1.0
 dependencies[] = system_incompatible_module_version_test (>2.0)
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/system_incompatible_module_version_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_module_version_test.info
@@ -5,7 +5,7 @@ version = 1.0
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/system_project_namespace_test.info
+++ b/html/modules/simpletest/tests/system_project_namespace_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = drupal:filter
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/system_test.info
+++ b/html/modules/simpletest/tests/system_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = system_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/taxonomy_test.info
+++ b/html/modules/simpletest/tests/taxonomy_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = taxonomy
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/theme.test
+++ b/html/modules/simpletest/tests/theme.test
@@ -238,6 +238,27 @@ class ThemeTableTestCase extends DrupalWebTestCase {
     $this->assertNoRaw('class="odd"', 'Odd/even classes were not added because $no_striping = TRUE.');
     $this->assertNoRaw('no_striping', 'No invalid no_striping HTML attribute was printed.');
   }
+
+  /**
+   * Test that the 'footer' option works correctly.
+   */
+  function testThemeTableFooter() {
+    $footer = array(
+      array(
+        'data' => array(1),
+      ),
+      array('Foo'),
+    );
+
+    $table = array(
+      'rows' => array(),
+      'footer' => $footer,
+    );
+
+    $this->content = theme('table', $table);
+    $this->content = preg_replace('@>\s+<@', '><', $this->content);
+    $this->assertRaw('<tfoot><tr><td>1</td></tr><tr><td>Foo</td></tr></tfoot>', 'Table footer found.');
+  }
 }
 
 /**

--- a/html/modules/simpletest/tests/theme_test.info
+++ b/html/modules/simpletest/tests/theme_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
+++ b/html/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 settings[basetheme_only] = base theme value
 settings[subtheme_override] = base theme value
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
+++ b/html/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 
 settings[subtheme_override] = subtheme value
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/themes/test_theme/test_theme.info
+++ b/html/modules/simpletest/tests/themes/test_theme/test_theme.info
@@ -17,7 +17,7 @@ stylesheets[all][] = system.base.css
 
 settings[theme_test_setting] = default value
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
+++ b/html/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
@@ -4,7 +4,7 @@ core = 7.x
 hidden = TRUE
 engine = nyan_cat
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/update_script_test.info
+++ b/html/modules/simpletest/tests/update_script_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/update_test_1.info
+++ b/html/modules/simpletest/tests/update_test_1.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/update_test_2.info
+++ b/html/modules/simpletest/tests/update_test_2.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/update_test_3.info
+++ b/html/modules/simpletest/tests/update_test_3.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/url_alter_test.info
+++ b/html/modules/simpletest/tests/url_alter_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/simpletest/tests/xmlrpc_test.info
+++ b/html/modules/simpletest/tests/xmlrpc_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/statistics/statistics.info
+++ b/html/modules/statistics/statistics.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = statistics.test
 configure = admin/config/system/statistics
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/statistics/statistics.module
+++ b/html/modules/statistics/statistics.module
@@ -74,8 +74,6 @@ function statistics_exit() {
     }
   }
   if (variable_get('statistics_enable_access_log', 0)) {
-    drupal_bootstrap(DRUPAL_BOOTSTRAP_SESSION);
-
     // For anonymous users unicode.inc will not have been loaded.
     include_once DRUPAL_ROOT . '/includes/unicode.inc';
     // Log this page access.

--- a/html/modules/syslog/syslog.info
+++ b/html/modules/syslog/syslog.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = syslog.test
 configure = admin/config/development/logging
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/system/system.archiver.inc
+++ b/html/modules/system/system.archiver.inc
@@ -38,10 +38,10 @@ class ArchiverTar implements ArchiverInterface {
 
   public function extract($path, Array $files = array()) {
     if ($files) {
-      $this->tar->extractList($files, $path);
+      $this->tar->extractList($files, $path, '', FALSE, FALSE);
     }
     else {
-      $this->tar->extract($path);
+      $this->tar->extract($path, FALSE, FALSE);
     }
 
     return $this;

--- a/html/modules/system/system.info
+++ b/html/modules/system/system.info
@@ -12,7 +12,7 @@ files[] = system.test
 required = TRUE
 configure = admin/config/system
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/system/system.module
+++ b/html/modules/system/system.module
@@ -323,6 +323,10 @@ function system_element_info() {
     '#group_callback' => 'drupal_group_css',
     '#aggregate_callback' => 'drupal_aggregate_css',
   );
+  $types['scripts'] = array(
+    '#items' => array(),
+    '#pre_render' => array('drupal_pre_render_scripts'),
+  );
 
   // Input elements.
   $types['submit'] = array(

--- a/html/modules/system/system.tar.inc
+++ b/html/modules/system/system.tar.inc
@@ -40,34 +40,22 @@
  */
 
  /**
- * Note on Drupal 8 porting.
- * This file origin is Tar.php, release 1.4.5 (stable) with some code
- * from PEAR.php, release 1.10.5 (stable) both at http://pear.php.net.
+ * Note on Drupal 7 porting.
+ * This file origin is Tar.php, release 1.4.9 (stable) with some code
+ * from PEAR.php, release 1.10.10 (stable) both at http://pear.php.net.
  * To simplify future porting from pear of this file, you should not
  * do cosmetic or other non significant changes to this file.
  * The following changes have been done:
- *  Added namespace Drupal\Core\Archiver.
  *  Removed require_once 'PEAR.php'.
  *  Added defintion of OS_WINDOWS taken from PEAR.php.
- *  Renamed class to ArchiveTar.
  *  Removed extends PEAR from class.
  *  Removed call parent:: __construct().
  *  Changed PEAR::loadExtension($extname) to this->loadExtension($extname).
  *  Added function loadExtension() taken from PEAR.php.
  *  Changed all calls of unlink() to drupal_unlink().
  *  Changed $this->error_object = &$this->raiseError($p_message)
- *  to throw new \Exception($p_message).
+ *  to throw new Exception($p_message).
  */
-
- /**
- * Note on Drupal 7 backporting from Drupal 8.
- * File origin is core/lib/Drupal/Core/Archiver/ArchiveTar.php from Drupal 8.
- * The following changes have been done:
- *  Removed namespace Drupal\Core\Archiver.
- *  Renamed class to Archive_Tar.
- *  Changed \Exception to Exception.
- */
-
 
 // Drupal removal require_once 'PEAR.php'.
 
@@ -154,6 +142,18 @@ class Archive_Tar
     public $error_object = null;
 
     /**
+     * Format for data extraction
+     *
+     * @var string
+     */
+    public $_fmt = '';
+
+    /**
+     * @var int Length of the read buffer in bytes
+     */
+    protected $buffer_length;
+
+    /**
      * Archive_Tar Class constructor. This flavour of the constructor only
      * declare a new Archive_Tar object, identifying it by the name of the
      * tar file.
@@ -165,10 +165,11 @@ class Archive_Tar
      *               parameter indicates if gzip, bz2 or lzma2 compression
      *               is required.  For compatibility reason the
      *               boolean value 'true' means 'gz'.
+     * @param int $buffer_length Length of the read buffer in bytes
      *
      * @return bool
      */
-    public function __construct($p_tarname, $p_compress = null)
+    public function __construct($p_tarname, $p_compress = null, $buffer_length = 512)
     {
         // Drupal removal parent::__construct().
 
@@ -263,15 +264,16 @@ class Archive_Tar
 
         if (version_compare(PHP_VERSION, "5.5.0-dev") < 0) {
             $this->_fmt = "a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/" .
-                   "a8checksum/a1typeflag/a100link/a6magic/a2version/" .
-                   "a32uname/a32gname/a8devmajor/a8devminor/a131prefix";
+                "a8checksum/a1typeflag/a100link/a6magic/a2version/" .
+                "a32uname/a32gname/a8devmajor/a8devminor/a131prefix";
         } else {
             $this->_fmt = "Z100filename/Z8mode/Z8uid/Z8gid/Z12size/Z12mtime/" .
-                   "Z8checksum/Z1typeflag/Z100link/Z6magic/Z2version/" .
-                   "Z32uname/Z32gname/Z8devmajor/Z8devminor/Z131prefix";
+                "Z8checksum/Z1typeflag/Z100link/Z6magic/Z2version/" .
+                "Z32uname/Z32gname/Z8devmajor/Z8devminor/Z131prefix";
         }
 
 
+        $this->buffer_length = $buffer_length;
     }
 
     public function __destruct()
@@ -371,11 +373,12 @@ class Archive_Tar
     /**
      * @param string $p_path
      * @param bool $p_preserve
+     * @param bool $p_symlinks
      * @return bool
      */
-    public function extract($p_path = '', $p_preserve = false)
+    public function extract($p_path = '', $p_preserve = false, $p_symlinks = true)
     {
-        return $this->extractModify($p_path, '', $p_preserve);
+        return $this->extractModify($p_path, '', $p_preserve, $p_symlinks);
     }
 
     /**
@@ -616,11 +619,12 @@ class Archive_Tar
      *                               removed if present at the beginning of
      *                               the file/dir path.
      * @param boolean $p_preserve Preserve user/group ownership of files
+     * @param boolean $p_symlinks Allow symlinks.
      *
      * @return boolean true on success, false on error.
      * @see    extractList()
      */
-    public function extractModify($p_path, $p_remove_path, $p_preserve = false)
+    public function extractModify($p_path, $p_remove_path, $p_preserve = false, $p_symlinks = true)
     {
         $v_result = true;
         $v_list_detail = array();
@@ -632,7 +636,8 @@ class Archive_Tar
                 "complete",
                 0,
                 $p_remove_path,
-                $p_preserve
+                $p_preserve,
+                $p_symlinks
             );
             $this->_close();
         }
@@ -676,11 +681,12 @@ class Archive_Tar
      *                               removed if present at the beginning of
      *                               the file/dir path.
      * @param boolean $p_preserve Preserve user/group ownership of files
+     * @param boolean $p_symlinks Allow symlinks.
      *
      * @return true on success, false on error.
      * @see    extractModify()
      */
-    public function extractList($p_filelist, $p_path = '', $p_remove_path = '', $p_preserve = false)
+    public function extractList($p_filelist, $p_path = '', $p_remove_path = '', $p_preserve = false, $p_symlinks = true)
     {
         $v_result = true;
         $v_list_detail = array();
@@ -701,7 +707,8 @@ class Archive_Tar
                 "partial",
                 $v_list,
                 $p_remove_path,
-                $p_preserve
+                $p_preserve,
+                $p_symlinks
             );
             $this->_close();
         }
@@ -1326,8 +1333,15 @@ class Archive_Tar
                 return false;
             }
 
-            while (($v_buffer = fread($v_file, 512)) != '') {
-                $v_binary_data = pack("a512", "$v_buffer");
+            while (($v_buffer = fread($v_file, $this->buffer_length)) != '') {
+                $buffer_length = strlen("$v_buffer");
+                if ($buffer_length != $this->buffer_length) {
+                    $pack_size = ((int)($buffer_length / 512) + 1) * 512;
+                    $pack_format = sprintf('a%d', $pack_size);
+                } else {
+                    $pack_format = sprintf('a%d', $this->buffer_length);
+                }
+                $v_binary_data = pack($pack_format, "$v_buffer");
                 $this->_writeBlock($v_binary_data);
             }
 
@@ -1532,7 +1546,8 @@ class Archive_Tar
         $p_type = '',
         $p_uid = 0,
         $p_gid = 0
-    ) {
+    )
+    {
         $p_filename = $this->_pathReduction($p_filename);
 
         if (strlen($p_filename) > 99) {
@@ -1745,7 +1760,16 @@ class Archive_Tar
         }
 
         // ----- Extract the checksum
-        $v_header['checksum'] = OctDec(trim($v_data['checksum']));
+        $v_data_checksum = trim($v_data['checksum']);
+        if (!preg_match('/^[0-7]*$/', $v_data_checksum)) {
+            $this->_error(
+                'Invalid checksum for file "' . $v_data['filename']
+                . '" : ' . $v_data_checksum . ' extracted'
+            );
+            return false;
+        }
+
+        $v_header['checksum'] = OctDec($v_data_checksum);
         if ($v_header['checksum'] != $v_checksum) {
             $v_header['filename'] = '';
 
@@ -1839,10 +1863,7 @@ class Archive_Tar
         if (strpos($file, 'phar://') === 0) {
             return true;
         }
-        if (strpos($file, DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR) !== false) {
-            return true;
-        }
-        if (strpos($file, '..' . DIRECTORY_SEPARATOR) === 0) {
+        if (strpos($file, '../') !== false || strpos($file, '..\\') !== false) {
             return true;
         }
         return false;
@@ -1908,19 +1929,23 @@ class Archive_Tar
             }
 
             switch ($v_header['typeflag']) {
-                case 'L': {
-                    if (!$this->_readLongHeader($v_header)) {
-                        return null;
+                case 'L':
+                    {
+                        if (!$this->_readLongHeader($v_header)) {
+                            return null;
+                        }
                     }
-                } break;
+                    break;
 
-                case 'K': {
-                    $v_link_header = $v_header;
-                    if (!$this->_readLongHeader($v_link_header)) {
-                        return null;
+                case 'K':
+                    {
+                        $v_link_header = $v_header;
+                        if (!$this->_readLongHeader($v_link_header)) {
+                            return null;
+                        }
+                        $v_header['link'] = $v_link_header['filename'];
                     }
-                    $v_header['link'] = $v_link_header['filename'];
-                } break;
+                    break;
             }
 
             if ($v_header['filename'] == $p_filename) {
@@ -1960,6 +1985,7 @@ class Archive_Tar
      * @param string $p_file_list
      * @param string $p_remove_path
      * @param bool $p_preserve
+     * @param bool $p_symlinks
      * @return bool
      */
     public function _extractList(
@@ -1968,8 +1994,10 @@ class Archive_Tar
         $p_mode,
         $p_file_list,
         $p_remove_path,
-        $p_preserve = false
-    ) {
+        $p_preserve = false,
+        $p_symlinks = true
+    )
+    {
         $v_result = true;
         $v_nb = 0;
         $v_extract_all = true;
@@ -2022,19 +2050,23 @@ class Archive_Tar
             }
 
             switch ($v_header['typeflag']) {
-                case 'L': {
-                    if (!$this->_readLongHeader($v_header)) {
-                        return null;
+                case 'L':
+                    {
+                        if (!$this->_readLongHeader($v_header)) {
+                            return null;
+                        }
                     }
-                } break;
+                    break;
 
-                case 'K': {
-                    $v_link_header = $v_header;
-                    if (!$this->_readLongHeader($v_link_header)) {
-                        return null;
+                case 'K':
+                    {
+                        $v_link_header = $v_header;
+                        if (!$this->_readLongHeader($v_link_header)) {
+                            return null;
+                        }
+                        $v_header['link'] = $v_link_header['filename'];
                     }
-                    $v_header['link'] = $v_link_header['filename'];
-                } break;
+                    break;
             }
 
             // ignore extended / pax headers
@@ -2146,6 +2178,13 @@ class Archive_Tar
                             }
                         }
                     } elseif ($v_header['typeflag'] == "2") {
+                        if (!$p_symlinks) {
+                            $this->_warning('Symbolic links are not allowed. '
+                                . 'Unable to extract {'
+                                . $v_header['filename'] . '}'
+                            );
+                            return false;
+                        }
                         if (@file_exists($v_header['filename'])) {
                             @drupal_unlink($v_header['filename']);
                         }

--- a/html/modules/system/tests/cron_queue_test.info
+++ b/html/modules/system/tests/cron_queue_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/system/tests/system_cron_test.info
+++ b/html/modules/system/tests/system_cron_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/taxonomy/taxonomy.info
+++ b/html/modules/taxonomy/taxonomy.info
@@ -8,7 +8,7 @@ files[] = taxonomy.module
 files[] = taxonomy.test
 configure = admin/structure/taxonomy
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/toolbar/toolbar-print.css
+++ b/html/modules/toolbar/toolbar-print.css
@@ -1,0 +1,6 @@
+/**
+ * Hide the toolbar when printing.
+ */
+#toolbar {
+  display: none;
+}

--- a/html/modules/toolbar/toolbar.info
+++ b/html/modules/toolbar/toolbar.info
@@ -4,7 +4,7 @@ core = 7.x
 package = Core
 version = VERSION
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/toolbar/toolbar.module
+++ b/html/modules/toolbar/toolbar.module
@@ -197,6 +197,9 @@ function toolbar_view() {
       ),
       'css' => array(
         $module_path . '/toolbar.css',
+        $module_path . '/toolbar-print.css' => array(
+          'media' => 'print',
+        ),
       ),
       'library' => array(array('system', 'jquery.cookie')),
     ),

--- a/html/modules/tracker/tracker.info
+++ b/html/modules/tracker/tracker.info
@@ -6,7 +6,7 @@ version = VERSION
 core = 7.x
 files[] = tracker.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/translation/tests/translation_test.info
+++ b/html/modules/translation/tests/translation_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/translation/translation.info
+++ b/html/modules/translation/translation.info
@@ -6,7 +6,7 @@ version = VERSION
 core = 7.x
 files[] = translation.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/trigger/tests/trigger_test.info
+++ b/html/modules/trigger/tests/trigger_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/trigger/trigger.info
+++ b/html/modules/trigger/trigger.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = trigger.test
 configure = admin/structure/trigger
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/update/tests/aaa_update_test.info
+++ b/html/modules/update/tests/aaa_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/update/tests/bbb_update_test.info
+++ b/html/modules/update/tests/bbb_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/update/tests/ccc_update_test.info
+++ b/html/modules/update/tests/ccc_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
+++ b/html/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
@@ -3,7 +3,7 @@ description = Test theme which acts as a base theme for other test subthemes.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
+++ b/html/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
@@ -4,7 +4,7 @@ core = 7.x
 base theme = update_test_basetheme
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/update/tests/update_test.info
+++ b/html/modules/update/tests/update_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/update/update.info
+++ b/html/modules/update/update.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = update.test
 configure = admin/reports/updates/settings
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/user/tests/user_form_test.info
+++ b/html/modules/user/tests/user_form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/user/tests/user_session_test.info
+++ b/html/modules/user/tests/user_session_test.info
@@ -1,5 +1,7 @@
-name = Update test admin theme
-description = Test theme which is used as admin theme.
+name = "User module session tests"
+description = "Support module for user session testing."
+package = Testing
+version = VERSION
 core = 7.x
 hidden = TRUE
 

--- a/html/modules/user/tests/user_session_test.module
+++ b/html/modules/user/tests/user_session_test.module
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Dummy module implementing a page callback to create an anon session.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function user_session_test_menu() {
+  $items = array();
+  $items['user_session_test_anon_session'] = array(
+    'page callback' => 'user_session_test_anon_session',
+    'access callback' => TRUE,
+  );
+  return $items;
+}
+
+/**
+ * Page callback.
+ *
+ * Creates an anonymous user session.
+ */
+function user_session_test_anon_session() {
+  $data = 'This dummy data will be stored in a user session.';
+  $_SESSION[__FUNCTION__] = $data;
+  return $data;
+}

--- a/html/modules/user/user.info
+++ b/html/modules/user/user.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/config/people
 stylesheets[all][] = user.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/modules/user/user.test
+++ b/html/modules/user/user.test
@@ -321,6 +321,10 @@ class UserLoginTestCase extends DrupalWebTestCase {
     );
   }
 
+  function setUp() {
+    parent::setUp('user_session_test');
+  }
+
   /**
    * Test the global login flood control.
    */
@@ -419,6 +423,17 @@ class UserLoginTestCase extends DrupalWebTestCase {
     // Load the stored user, which should have a different password hash now.
     $account = user_load($account->uid, TRUE);
     $this->assertIdentical(_password_get_count_log2($account->pass), DRUPAL_HASH_COUNT + 1);
+  }
+
+  /**
+   * Test logging in when an anon session already exists.
+   */
+  function testLoginWithAnonSession() {
+    // Visit the callback to generate a session for this anon user.
+    $this->drupalGet('user_session_test_anon_session');
+    // Now login.
+    $account = $this->drupalCreateUser(array());
+    $this->drupalLogin($account);
   }
 
   /**

--- a/html/profiles/minimal/minimal.info
+++ b/html/profiles/minimal/minimal.info
@@ -5,7 +5,7 @@ core = 7.x
 dependencies[] = block
 dependencies[] = dblog
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/profiles/standard/standard.info
+++ b/html/profiles/standard/standard.info
@@ -24,7 +24,7 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = rdf
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/html/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 files[] = drupal_system_listing_compatible_test.test
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/html/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -8,7 +8,7 @@ version = VERSION
 core = 6.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/profiles/testing/testing.info
+++ b/html/profiles/testing/testing.info
@@ -4,7 +4,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/themes/bartik/bartik.info
+++ b/html/themes/bartik/bartik.info
@@ -34,7 +34,7 @@ regions[footer] = Footer
 settings[shortcut_module_link] = 0
 
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/themes/garland/garland.info
+++ b/html/themes/garland/garland.info
@@ -7,7 +7,7 @@ stylesheets[all][] = style.css
 stylesheets[print][] = print.css
 settings[garland_width] = fluid
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/themes/seven/seven.info
+++ b/html/themes/seven/seven.info
@@ -13,7 +13,7 @@ regions[page_bottom] = Page bottom
 regions[sidebar_first] = First sidebar
 regions_hidden[] = sidebar_first
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/themes/stark/stark.info
+++ b/html/themes/stark/stark.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 stylesheets[all][] = layout.css
 
-; Information added by Drupal.org packaging script on 2019-05-08
-version = "7.67"
+; Information added by Drupal.org packaging script on 2019-12-18
+version = "7.69"
 project = "drupal"
-datestamp = "1557336079"
+datestamp = "1576696221"

--- a/html/web.config
+++ b/html/web.config
@@ -6,7 +6,7 @@
     <rewrite>
       <rules>
         <rule name="Protect files and directories from prying eyes" stopProcessing="true">
-          <match url="\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)$|^(\..*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$" />
+          <match url="\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)$|^(\..*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|\.htaccess)$" />
           <action type="CustomResponse" statusCode="403" subStatusCode="0" statusReason="Forbidden" statusDescription="Access is forbidden." />
         </rule>
         <rule name="Force simple error message for requests for non-existent favicon.ico" stopProcessing="true">


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/HRINFO-997

I expected this could be done with composer, but I found I could only update everything, including all the modules, or, with `composer update drupal/drupal` only a handful of modules, but not core. 

(I'd like to update all the modules that aren't pinned, but that would require more extensive testing.)

So the update was done with drush and then manually applying the patches. (Some will need adjustment now the drupal root is in the `html` directory. I'll leave that for another ticket when I understand the composer workflow better.)