### PR TITLE
OPS-6101 return plain value - not an array for text fields.

### DIFF
--- a/html/sites/all/modules/hr/hr_assessments/src/Plugin/resource/RestfulEntityNodeAssessments.php
+++ b/html/sites/all/modules/hr/hr_assessments/src/Plugin/resource/RestfulEntityNodeAssessments.php
@@ -85,14 +85,20 @@ class RestfulEntityNodeAssessments extends ResourceCustom implements ResourceInt
 
     $public_fields['subject'] = array(
       'property' => 'field_asst_subject',
+      'sub_property' => 'value',
+      'process_callbacks' => array('strip_tags', 'trim'),
     );
 
     $public_fields['methodology'] = array(
       'property' => 'field_asst_methodology',
+      'sub_property' => 'value',
+      'process_callbacks' => array('strip_tags', 'trim'),
     );
 
     $public_fields['key_findings'] = array(
       'property' => 'field_asst_key_findings',
+      'sub_property' => 'value',
+      'process_callbacks' => array('strip_tags', 'trim'),
     );
 
     $public_fields['unit_measurement'] = array(


### PR DESCRIPTION
Also running strip_tags and trim to maintain consistency with the fields' original appearance as plain text fields.