### PR TITLE
[OPS-5482] Pick a dropped Redis patch (that aims to fix lockups on cache entry delete) up off the floor.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8043,6 +8043,7 @@
                 },
                 "patches_applied": {
                     "Use path_alias_xt when installed": "PATCHES/drupal-undefined_function_drupal_get_path_alias-2842762-14-D7-PART2-2420275-1-path_alias_xt.patch",
+                    "New feature: option to use SCAN command instead of KEYS on cache wildcard deletions": "https://www.drupal.org/files/issues/2018-05-07/redis-delete-by-prefix-using-scan-2851625-21.patch",
                     "[D7] Not compatible with php-redis 5": "https://www.drupal.org/files/issues/2019-11-27/redis-n3074189-23.patch"
                 }
             },

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -29,7 +29,8 @@
       },
       "drupal/redis": {
         "Use path_alias_xt when installed": "PATCHES/drupal-undefined_function_drupal_get_path_alias-2842762-14-D7-PART2-2420275-1-path_alias_xt.patch",
-         "[D7] Not compatible with php-redis 5": "https://www.drupal.org/files/issues/2019-11-27/redis-n3074189-23.patch"
+        "New feature: option to use SCAN command instead of KEYS on cache wildcard deletions": "https://www.drupal.org/files/issues/2018-05-07/redis-delete-by-prefix-using-scan-2851625-21.patch",
+        "[D7] Not compatible with php-redis 5": "https://www.drupal.org/files/issues/2019-11-27/redis-n3074189-23.patch"
       },
       "drupal/restful": {
         "HR.info issue 754": "PATCHES/restful-754.patch"

--- a/html/sites/all/modules/contrib/redis/PATCHES.txt
+++ b/html/sites/all/modules/contrib/redis/PATCHES.txt
@@ -5,6 +5,10 @@ Use path_alias_xt when installed
 Source: PATCHES/drupal-undefined_function_drupal_get_path_alias-2842762-14-D7-PART2-2420275-1-path_alias_xt.patch
 
 
+New feature: option to use SCAN command instead of KEYS on cache wildcard deletions
+Source: https://www.drupal.org/files/issues/2018-05-07/redis-delete-by-prefix-using-scan-2851625-21.patch
+
+
 [D7] Not compatible with php-redis 5
 Source: https://www.drupal.org/files/issues/2019-11-27/redis-n3074189-23.patch
 


### PR DESCRIPTION
This is a follow-up to https://github.com/UN-OCHA/hrinfo-site/pull/894 which *may* not be needed, now that the cache logic is better in redis 3.18.

Keeping it ready just in case we start running into cache-clear induced slowdowns again though.