### PR TITLE
[OPS-5482][OPS-6141] Ensure the site directory is available where Dru…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,3 +24,7 @@ COPY ./html /srv/www/html
 COPY ./composer.json /srv/www/composer.json
 COPY ./composer.lock /srv/www/composer.lock
 COPY ./composer.patches.json /srv/www/composer.patches.json
+
+RUN  cd /srv/www/html/sites && \
+       rm -f www.humanitarianresponse.info && \
+       ln -s default www.humanitarianresponse.info


### PR DESCRIPTION
…pal expects it.

The Ansible-generated config (and existing site content) all assume
sites/www.humanitarianresponse.info/files so if that does not exist,
file handling breaks.