### PR TITLE
[OPS-5482] Maintain nginx based redirects.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ COPY ./html /srv/www/html
 COPY ./composer.json /srv/www/composer.json
 COPY ./composer.lock /srv/www/composer.lock
 COPY ./composer.patches.json /srv/www/composer.patches.json
+COPY ./docker/custom /etc/nginx/custom
 
 RUN  cd /srv/www/html/sites && \
        rm -f www.humanitarianresponse.info && \

--- a/docker/custom/01-hrinfo.conf
+++ b/docker/custom/01-hrinfo.conf
@@ -1,0 +1,8 @@
+# -*- mode: nginx; mode: flyspell-prog;  ispell-local-dictionary: "american" -*-
+
+## HRinfo redirects. Redirect with a 301.
+
+## https://humanitarian.atlassian.net/browse/HRINFO-926
+location =/sites/www.humanitarianresponse.info/files/2019/04/Operation-Presence-Map-WASH_0409_final.pdf {
+  return 301 /sites/www.humanitarianresponse.info/files/documents/files/operation_presence_map_wash_0409_final.pdf;
+}

--- a/docker/custom/02-hpc-ir.conf
+++ b/docker/custom/02-hpc-ir.conf
@@ -1,0 +1,50 @@
+# -*- mode: nginx; mode: flyspell-prog;  ispell-local-dictionary: "american" -*-
+
+## Indicator Registry redirects. Redirect with a 301.
+## See https://humanitarian.atlassian.net/browse/OPS-3090
+
+## Content pages.
+location ~ /(en|fr|ru|es)/applications/ir/indicators {
+  return 301 https://ir.hpc.tools/$1/applications/ir/indicators;
+}
+
+location ~ /(en|fr|ru|es)/applications/ir {
+  return 301 https://ir.hpc.tools/;
+}
+
+## API Endpoints.
+location ~ /(en|fr|ru|es)/api/v1.0/indicators {
+  return 301 https://ir.hpc.tools/$1/api/v1.0/indicators;
+}
+
+location ~ /(en|fr|ru|es)/api/v1.0/indicator_standards {
+  return 301 https://ir.hpc.tools/$1/api/v1.0/indicator_standards;
+}
+
+location ~ /(en|fr|ru|es)/api/v1.0/indicator_domains {
+  return 301 https://ir.hpc.tools/$1/api/v1.0/indicator_domains;
+}
+
+location ~ /(en|fr|ru|es)/api/v1.0/indicator_types {
+  return 301 https://ir.hpc.tools/$1/api/v1.0/indicator_types;
+}
+
+location ~ /(en|fr|ru|es)/api/v1.0/indicator_units {
+  return 301 https://ir.hpc.tools/$1/api/v1.0/indicator_units;
+}
+
+location ^~ /api/v1.0/indicators {
+  return 301 https://ir.hpc.tools/api/v1.0/indicators;
+}
+
+location ^~ /api/v1.0/indicator_standards {
+  return 301 https://ir.hpc.tools/api/v1.0/indicator_standards;
+}
+
+location ^~ /api/v1.0/indicator_domains {
+  return 301 https://ir.hpc.tools/api/v1.0/indicator_domains;
+}
+
+location ^~ /api/v1.0/indicator_types {
+  return 301 https://ir.hpc.tools/api/v1.0/indicator_types;
+}


### PR DESCRIPTION
Except (www.)?salahumanitaria.co which points at Colombia's own web
redirector and is no lomger handled by us.