### PR TITLE
[HRINFO-1000] remove language validation for clusters and operations

### DIFF
--- a/html/sites/all/modules/hr/hr_core/hr_core.module
+++ b/html/sites/all/modules/hr/hr_core/hr_core.module
@@ -1637,13 +1637,11 @@ function hr_core_entity_property_info_alter(&$entity_info) {
 /**
  * Implements hook_node_validate()
  *
- * Makes sure clusters, operations and offices have an English translation.
+ * Makes sure offices have an English translation.
  */
 function hr_core_node_validate($node, $form, &$form_state) {
-  $node_types = array('hr_bundle', 'hr_operation', 'hr_office');
+  $node_types = array('hr_office');
   $node_labels = array(
-    'hr_bundle' => t('Cluster'),
-    'hr_operation' => t('Operation'),
     'hr_office' => t('Office')
   );
   if (in_array($node->type, $node_types) && $node->language !== 'en') {


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/HRINFO-1000

Related to https://humanitarian.atlassian.net/browse/HRINFO-949 and https://humanitarian.atlassian.net/browse/HID-1812

See the 'lock_language' setting in `hr_bundles.strongarm.inc`:
```
entity_translation_settings_node__hr_bundle:
  default_language: xx-et-current
  hide_language_selector: 0
  exclude_language_none: 1
  lock_language: 1
  shared_fields_original_only: 0
```
and also for 'operations', but not for 'offices'.
(not sure what the default_language setting is there - perhaps setting it to English would be a fix for the HID issue)