### PR TITLE
[OPS-6585] Bump the docker image for a NewRelic segfault-on-long-tasks fix.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM unocha/php7-k8s:7.2.27-r0-202003-03-NR
+FROM unocha/php7-k8s:7.2.27-r0-202004-02-NR
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
Cherry pick the image version bump into master, so we can deploy *just* that and fix the cron job errors.