### PR TITLE
[OPS-6809] Add the memcache module. Do not enable it, that is managed in settings.php via Ansible.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
         "drupal/media": "2.19",
         "drupal/media_vimeo": "^2.1",
         "drupal/media_youtube": "^3.8",
+        "drupal/memcache": "^1.8",
         "drupal/menu_target": "^1.7",
         "drupal/modernizr": "^3.11",
         "drupal/moment": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "787b0059a4456bfb70ffc41a9f95d57b",
+    "content-hash": "6610a7fd2d314e58a3dbba77de716cef",
     "packages": [
         {
             "name": "composer/installers",
@@ -536,10 +536,6 @@
                     "homepage": "https://www.drupal.org/user/216396"
                 },
                 {
-                    "name": "colan",
-                    "homepage": "https://www.drupal.org/user/58704"
-                },
-                {
                     "name": "diqidoq",
                     "homepage": "https://www.drupal.org/user/1001934"
                 },
@@ -832,6 +828,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-3.5",
                     "datestamp": "1413299929",
@@ -851,16 +850,20 @@
                     "homepage": "https://www.drupal.org/user/45874"
                 },
                 {
-                    "name": "Neslee Canil Pinto",
-                    "homepage": "https://www.drupal.org/user/3580850"
-                },
-                {
                     "name": "fizk",
                     "homepage": "https://www.drupal.org/user/473174"
                 },
                 {
-                    "name": "solide-echt",
-                    "homepage": "https://www.drupal.org/user/46176"
+                    "name": "geertvd",
+                    "homepage": "https://www.drupal.org/user/536694"
+                },
+                {
+                    "name": "pjonckiere",
+                    "homepage": "https://www.drupal.org/user/2442998"
+                },
+                {
+                    "name": "tedbow",
+                    "homepage": "https://www.drupal.org/user/240860"
                 }
             ],
             "description": "Views plugin to display views containing dates as Calendars.",
@@ -1516,6 +1519,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-2.10",
                     "datestamp": "1491562115",
@@ -3071,6 +3077,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-2.11",
                     "datestamp": "1541189192",
@@ -3100,10 +3109,6 @@
                 {
                     "name": "febbraro",
                     "homepage": "https://www.drupal.org/user/43670"
-                },
-                {
-                    "name": "flocondetoile",
-                    "homepage": "https://www.drupal.org/user/2006064"
                 },
                 {
                     "name": "jmiccolis",
@@ -5904,6 +5909,78 @@
             }
         },
         {
+            "name": "drupal/memcache",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/memcache.git",
+                "reference": "7.x-1.8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/memcache-7.x-1.8.zip",
+                "reference": "7.x-1.8",
+                "shasum": "89395ddc7bdae9d4a34e42a1bd62078c7b910587"
+            },
+            "require": {
+                "drupal/drupal": "~7.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "7.x-1.8",
+                    "datestamp": "1594981706",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/7/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Fabianx",
+                    "homepage": "https://www.drupal.org/user/693738"
+                },
+                {
+                    "name": "Jeremy",
+                    "homepage": "https://www.drupal.org/user/409"
+                },
+                {
+                    "name": "bdragon",
+                    "homepage": "https://www.drupal.org/user/53081"
+                },
+                {
+                    "name": "catch",
+                    "homepage": "https://www.drupal.org/user/35733"
+                },
+                {
+                    "name": "damiankloip",
+                    "homepage": "https://www.drupal.org/user/1037976"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "jvandyk",
+                    "homepage": "https://www.drupal.org/user/2375"
+                },
+                {
+                    "name": "robertDouglass",
+                    "homepage": "https://www.drupal.org/user/5449"
+                }
+            ],
+            "description": "High performance integration with memcache.",
+            "homepage": "https://www.drupal.org/project/memcache",
+            "support": {
+                "source": "https://git.drupalcode.org/project/memcache"
+            }
+        },
+        {
             "name": "drupal/menu_target",
             "version": "1.7.0",
             "source": {
@@ -6122,9 +6199,12 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-2.7",
-                    "datestamp": "1582667821",
+                    "datestamp": "1497976586",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7006,10 +7086,6 @@
                     "homepage": "https://www.drupal.org/user/45640"
                 },
                 {
-                    "name": "joelpittet",
-                    "homepage": "https://www.drupal.org/user/160302"
-                },
-                {
                     "name": "merlinofchaos",
                     "homepage": "https://www.drupal.org/user/26979"
                 },
@@ -7020,6 +7096,10 @@
                 {
                     "name": "samuel.mortenson",
                     "homepage": "https://www.drupal.org/user/2582268"
+                },
+                {
+                    "name": "sdboyer",
+                    "homepage": "https://www.drupal.org/user/146719"
                 },
                 {
                     "name": "tim.plunkett",
@@ -7903,6 +7983,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-1.0-rc3",
                     "datestamp": "1436393339",
@@ -8348,6 +8431,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-1.26",
                     "datestamp": "1552334580",
@@ -9171,6 +9257,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1485316084",
@@ -9236,6 +9325,9 @@
             },
             "type": "drupal-module",
             "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
                 "drupal": {
                     "version": "7.x-1.1",
                     "datestamp": "1325700944",
@@ -10320,7 +10412,7 @@
                 },
                 "drupal": {
                     "version": "7.x-2.6",
-                    "datestamp": "1563520137",
+                    "datestamp": "1563397062",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/html/sites/all/modules/contrib/memcache/LICENSE.txt
+++ b/html/sites/all/modules/contrib/memcache/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/html/sites/all/modules/contrib/memcache/README.txt
+++ b/html/sites/all/modules/contrib/memcache/README.txt
@@ -1,0 +1,777 @@
+## IMPORTANT NOTE ##
+
+This file contains installation instructions for the 7.x-1.x version of the
+Drupal Memcache module. Configuration differs between 7.x and 6.x versions
+of the module, so be sure to follow the 6.x instructions if you are configuring
+the 6.x-1.x version of this module!
+
+## REQUIREMENTS ##
+
+- PHP 5.1 or greater
+- Availability of a memcached daemon: http://memcached.org/
+- One of the two PECL memcache packages:
+  - http://pecl.php.net/package/memcache (recommended)
+  - http://pecl.php.net/package/memcached (latest versions require PHP 5.2 or
+    greater)
+
+## INSTALLATION ##
+
+These are the steps you need to take in order to use this software. Order
+is important.
+
+ 1. Install the memcached binaries on your server and start the memcached
+    service. Follow best practices for securing the service; for example,
+    lock it down so only your web servers can make connections. Find community
+    maintained documentation with a number of walk-throughs for various
+    operating systems at https://www.drupal.org/node/1131458.
+ 2. Install your chosen PECL memcache extension -- this is the memcache client
+    library which will be used by the Drupal memcache module to interact with
+    the memcached server(s). Generally PECL memcache (3.0.6+) is recommended,
+    but PECL memcached (2.0.1+) also works well for some people. There are
+    known issues with older versions. Refer to the community maintained
+    documentation referenced above for more information.
+ 3. Put your site into offline mode.
+ 4. Download and install the memcache module.
+ 5. If you have previously been running the memcache module, run update.php.
+ 6. Optionally edit settings.php to configure the servers, clusters and bins
+    for memcache to use. If you skip this step the Drupal module will attempt to
+    talk to the memcache server on port 11211 on the local host, storing all
+    data in a single bin. This is sufficient for most smaller, single-server
+    installations.
+ 7. Edit settings.php to make memcache the default cache class, for example:
+      $conf['cache_backends'][] = 'sites/all/modules/memcache/memcache.inc';
+      $conf['cache_default_class'] = 'MemCacheDrupal';
+    The cache_backends path needs to be adjusted based on where you installed
+    the module.
+ 8. Make sure the following line also exists, to ensure that the special
+    cache_form bin is assigned to non-volatile storage:
+      $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+ 9. Optionally also add the following two lines to tell Drupal not to bootstrap
+    the database when serving cached pages to anonymous visitors:
+      $conf['page_cache_without_database'] = TRUE;
+      $conf['page_cache_invoke_hooks'] = FALSE;
+    If setting page_cache_without_database to TRUE, you also have to set
+    page_cache_invoke_hooks to FALSE or you'll see an error like "Fatal error:
+    Call to undefined function module_list()".
+10. Bring your site back online.
+
+## DRUSH ##
+
+Enable the memcache module at admin/modules or with 'drush en memcache', then
+rebuild the drush cache by running 'drush cc drush'. This will enable the
+following drush commands:
+
+  memcache-flush (mcf)  Flush all Memcached objects in a bin.
+  memcache-stats (mcs)  Retrieve statistics from Memcached.
+
+For more information about each command, use 'drush help'. For example:
+  drush help mcf
+
+Or:
+  drush help mcs
+
+## ADVANCED CONFIGURATION ##
+
+This module is capable of working with one memcached instance or with multiple
+memcached instances run across one or more servers. The default is to use one
+server accessible on localhost port 11211. If that meets your needs, then the
+configuration settings outlined above are sufficient for the module to work.
+If you want to use multiple memcached instances, or if you are connecting to a
+memcached instance located on a remote machine, further configuration is
+required.
+
+The available memcached servers are specified in $conf in settings.php. If you
+do not specify any servers, memcache.inc assumes that you have a memcached
+instance running on localhost:11211. If this is true, and it is the only
+memcached instance you wish to use, no further configuration is required.
+
+If you have more than one memcached instance running, you need to add two arrays
+to $conf; memcache_servers and memcache_bins. The arrays follow this pattern:
+
+'memcache_servers' => array(
+  server1:port => cluster1,
+  server2:port => cluster2,
+  serverN:port => clusterN,
+  'unix:///path/to/socket' => clusterS
+)
+
+'memcache_bins' => array(
+   bin1 => cluster1,
+   bin2 => cluster2,
+   binN => clusterN,
+   binS => clusterS
+)
+
+You can optionally assign a weight to each server, favoring one server more than
+another. For example, to make it 10 times more likely to store an item on
+server1 versus server2:
+
+'memcache_servers' => array(
+  server1:port => array('cluster' => cluster1, 'weight' => 10),
+  server2:port => array('cluster' => cluster2, 'weight' => 1'),
+)
+
+The bin/cluster/server model can be described as follows:
+
+- Servers are memcached instances identified by host:port.
+
+- Clusters are groups of servers that act as a memory pool. Each cluster can
+  contain one or more servers.
+
+- Bins are groups of data that get cached together and map 1:1 to the $table
+  parameter of cache_set(). Examples from Drupal core are cache_filter and
+  cache_menu. The default is 'cache'.
+
+- Multiple bins can be assigned to a cluster.
+
+- The default cluster is 'default'.
+
+## LOCKING ##
+
+The memcache-lock.inc file included with this module can be used as a drop-in
+replacement for the database-mediated locking mechanism provided by Drupal
+core. To enable, define the following in your settings.php:
+
+  $conf['lock_inc'] = 'sites/all/modules/memcache/memcache-lock.inc';
+
+Locks are written in the 'semaphore' table, which will map to the 'default'
+memcache cluster unless you explicitly configure a 'semaphore' cluster.
+
+## STAMPEDE PROTECTION ##
+
+Memcache includes stampede protection for rebuilding expired cache items. To
+enable stampede protection, define the following in settings.php:
+
+  $conf['memcache_stampede_protection'] = TRUE;
+
+To avoid lock stampedes, it is important that you enable the memcache lock
+implementation when enabling stampede protection -- enabling stampede protection
+without enabling the Memcache lock implementation can cause worse performance and
+can result in dropped locks due to key-length truncation.
+
+Memcache stampede protection is primarily designed to benefit the following
+caching pattern: a miss on a cache_get() for a specific cid is immediately
+followed by a cache_set() for that cid. Of course, this is not the only caching
+pattern used in Drupal, so stampede protection can be selectively disabled for
+optimal performance.  For example, a cache miss in Drupal core's
+module_implements() won't execute a cache_set until drupal_page_footer()
+calls module_implements_write_cache() which can occur much later in page
+generation.  To avoid long hanging locks, stampede protection should be
+disabled for these delayed caching patterns.
+
+Memcache stampede protection can be disabled for entire bins, specific cid's in
+specific bins, or cid's starting with a specific prefix in specific bins. For
+example:
+
+  $conf['memcache_stampede_protection_ignore'] = array(
+    // Ignore some cids in 'cache_bootstrap'.
+    'cache_bootstrap' => array(
+      'module_implements',
+      'variables',
+      'lookup_cache',
+      'schema:runtime:*',
+      'theme_registry:runtime:*',
+      '_drupal_file_scan_cache',
+    ),
+    // Ignore all cids in the 'cache' bin starting with 'i18n:string:'
+    'cache' => array(
+      'i18n:string:*',
+    ),
+    // Disable stampede protection for the entire 'cache_path' and 'cache_rules'
+    // bins.
+    'cache_path',
+    'cache_rules',
+  );
+
+Only change the following stampede protection tunables if you're sure you know
+what you're doing, which requires first reading the memcache.inc code.
+
+The value passed to lock_acquire, defaults to '15':
+  $conf['memcache_stampede_semaphore'] = 15;
+
+The value passed to lock_wait, defaults to 5:
+  $conf['memcache_stampede_wait_time'] = 5;
+
+The maximum number of calls to lock_wait() due to stampede protection during a
+single request, defaults to 3:
+  $conf['memcache_stampede_wait_limit'] = 3;
+
+When adjusting these variables, be aware that:
+ - there is unlikely to be a good use case for setting wait_time higher
+   than stampede_semaphore;
+ - wait_time * wait_limit is designed to default to a number less than
+   standard web server timeouts (i.e. 15 seconds vs. apache's default of
+   30 seconds).
+
+## CACHE LIFETIME ##
+
+Memcache respects Drupal core's minimum cache lifetime configuration. This
+setting affects all cached items, not just pages. In some cases, it may
+be desirable to cache different types of items for different amounts of time.
+You can override the minimum cache lifetime on a per-bin basis in settings.php.
+For example:
+
+  // Cache pages for 60 seconds.
+  $conf['cache_lifetime_cache_page'] = 60;
+  // Cache menus for 10 minutes.
+  $conf['cache_lifetime_menu'] = 600;
+
+## CACHE HEADER ##
+
+Drupal core indicates whether or not a page was served out of the cache by
+setting the 'X-Drupal-Cache' response header with a value of HIT or MISS. If
+you'd like to confirm whether pages are actually being retreived from Memcache
+and not another backend, you can enable the following option:
+
+  $conf['memcache_pagecache_header'] = TRUE;
+
+When enabled, the Memcache module will add its own 'Drupal-PageCache-Memcache'
+header. When cached pages are served out of the cache the header will include an
+'age=' value indicating how many seconds ago the page was stored in the cache.
+
+## PERSISTENT CONNECTIONS ##
+
+As of 7.x-1.6, the memcache module uses peristent connections by default. If
+this causes you problems you can disable persistent connections by adding the
+following to your settings.php:
+
+  $conf['memcache_persistent'] = FALSE;
+
+## STRICT COMPATIBILITY WITH DB CACHE EXPIRATIONS ##
+
+Due to the way database caching works, the native Drupal cache will return
+expired cache objects which were set to expire in the future even after their
+expiration timestamp, because it doesn't clean up cache entries until the
+cache bins are garbage collected (normally during a cron.php run's general
+cache wipe). However, memcache can expire cached items at the specific time
+requested. Therefore the default behavior of the memcache module does not
+match the Drupal API for cache_set, which states that cache items set to
+expire in the future are kept at least until the given timestamp, after which
+they behave like CACHE_TEMPORARY (removed at the next general cache wipe).
+
+If you wish to return to the behavior described in the cache_set API, and
+allow expired entries to appear valid until a general cache wipe, define the
+following in settings.php:
+
+  $conf['memcache_expire_wait_gc'] = TRUE;
+
+This setting works independently from stampede support, though it changes the
+time at which timestamp-cached items are considered expired, and therefore
+affects the time at which stampede behavior happens (if enabled).
+
+## EXAMPLES ##
+
+Example 1:
+
+First, the most basic configuration which consists of one memcached instance
+running on localhost port 11211 and all caches except for cache_form being
+stored in memcache. We also enable stampede protection, and the memcache
+locking mechanism. Finally, we tell Drupal to not bootstrap the database when
+serving cached pages to anonymous visitors.
+
+  $conf['cache_backends'][] = 'sites/all/modules/memcache/memcache.inc';
+  $conf['lock_inc'] = 'sites/all/modules/memcache/memcache-lock.inc';
+  $conf['memcache_stampede_protection'] = TRUE;
+  $conf['cache_default_class'] = 'MemCacheDrupal';
+
+  // The 'cache_form' bin must be assigned to non-volatile storage.
+  $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+
+  // Don't bootstrap the database when serving pages from the cache.
+  $conf['page_cache_without_database'] = TRUE;
+  $conf['page_cache_invoke_hooks'] = FALSE;
+
+Note that no servers or bins are defined.  The default server and bin
+configuration which is used in this case is equivalant to setting:
+
+  $conf['memcache_servers'] = array('localhost:11211' => 'default');
+
+
+Example 2:
+
+In this example we define three memcached instances, two accessed over the
+network, and one on a Unix socket -- please note this is only an illustration of
+what is possible, and is not a recommended configuration as it's highly unlikely
+you'd want to configure memcache to use both sockets and network addresses like
+this, instead you'd consistently use one or the other.
+
+The instance on port 11211 belongs to the 'default' cluster where everything
+gets cached that isn't otherwise defined. (We refer to it as a "cluster", but in
+this example our "clusters" involve only one instance.) The instance on port
+11212 belongs to the 'pages' cluster, with the 'cache_page' table mapped to
+it -- so the Drupal page cache is stored in this cluster.  Finally, the instance
+listening on a socket is part of the 'blocks' cluster, with the 'cache_block'
+table mapped to it -- so the Drupal block cache is stored here. Note that
+sockets do not have ports.
+
+  $conf['cache_backends'][] = 'sites/all/modules/memcache/memcache.inc';
+  $conf['lock_inc'] = 'sites/all/modules/memcache/memcache-lock.inc';
+  $conf['memcache_stampede_protection'] = TRUE;
+  $conf['cache_default_class'] = 'MemCacheDrupal';
+
+  // The 'cache_form' bin must be assigned no non-volatile storage.
+  $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+
+  // Don't bootstrap the database when serving pages from the cache.
+  $conf['page_cache_without_database'] = TRUE;
+  $conf['page_cache_invoke_hooks'] = FALSE;
+
+  // Important to define a default cluster in both the servers
+  // and in the bins. This links them together.
+  $conf['memcache_servers'] = array('10.1.1.1:11211' => 'default',
+                                    '10.1.1.1:11212' => 'pages',
+                                    'unix:///path/to/socket' => 'blocks');
+  $conf['memcache_bins'] = array('cache' => 'default',
+                                 'cache_page' => 'pages',
+                                 'cache_block' => 'blocks');
+
+
+Example 3:
+
+Here is an example configuration that has two clusters, 'default' and
+'cluster2'. Five memcached instances running on four different servers are
+divided up between the two clusters. The 'cache_filter' and 'cache_menu' bins
+go to 'cluster2'. All other bins go to 'default'.
+
+  $conf['cache_backends'][] = 'sites/all/modules/memcache/memcache.inc';
+  $conf['lock_inc'] = 'sites/all/modules/memcache/memcache-lock.inc';
+  $conf['memcache_stampede_protection'] = TRUE;
+  $conf['cache_default_class'] = 'MemCacheDrupal';
+
+  // The 'cache_form' bin must be assigned no non-volatile storage.
+  $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+
+  // Don't bootstrap the database when serving pages from the cache.
+  $conf['page_cache_without_database'] = TRUE;
+  $conf['page_cache_invoke_hooks'] = FALSE;
+
+  $conf['memcache_servers'] = array('10.1.1.6:11211' => 'default',
+                                    '10.1.1.6:11212' => 'default',
+                                    '10.1.1.7:11211' => 'default',
+                                    '10.1.1.8:11211' => 'cluster2',
+                                    '10.1.1.9:11211' => 'cluster2');
+
+  $conf['memcache_bins'] = array('cache' => 'default',
+                                 'cache_filter' => 'cluster2',
+                                 'cache_menu' => 'cluster2');
+  );
+
+## PREFIXING ##
+
+If you want to have multiple Drupal installations share memcached instances,
+you need to include a unique prefix for each Drupal installation in the $conf
+array of settings.php. This can be a single string prefix, or a keyed array of
+bin => prefix pairs:
+
+   $conf['memcache_key_prefix'] = 'something_unique';
+
+Using a per-bin prefix:
+
+   $conf['memcache_key_prefix'] = array(
+     'default' => 'something_unique',
+     'cache_page' => 'something_else_unique'
+   );
+
+In the above example, the 'something_unique' prefix will be used for all bins
+except for the 'cache_page' bin which will use the 'something_else_unique'
+prefix. Note that if using a keyed array for specifying prefix, you must specify
+the 'default' prefix.
+
+It is also possible to specify multiple prefixes per bin. Only the first prefix
+will be used when setting/getting cache items, but all prefixes will be cleared
+when deleting cache items. This provides support for more complicated
+configurations such as a live instance and an administrative instance each with
+their own prefixes and therefore their own unique caches. Any time a cache item
+is deleted on either instance, it gets flushed on both -- thus, should an admin
+do something that flushes the page cache, it will appropriately get flushed on
+both instances. (For more discussion see the issue where support was added,
+https://www.drupal.org/node/1084448.) This feature is enabled when you configure
+prefixes as arrays within arrays. For example:
+
+  // Live instance.
+  $conf['memcache_key_prefix'] = array(
+    'default' => array(
+      'live_unique', // live cache prefix
+      'admin_unique', // admin cache prefix
+    ),
+  );
+
+The above would be the configuration of your live instance. Then, on your
+administrative instance you would flip the keys:
+
+  // Administrative instance.
+  $conf['memcache_key_prefix'] = array(
+    'default' => array(
+      'admin_unique', // admin cache prefix
+      'live_unique', // live cache prefix
+    ),
+  );
+
+## EXPERIMENTAL - ALTERNATIVE SERIALIZE ##
+
+This is a new experimental feature added to the memcache module in version
+7.x-1.6 and should be tested carefully before utilizing in production.
+
+To optimize how data is serialized before it is written to memcache, you can
+enable either the igbinary or msgpack PECL extension. Both switch from using
+PHP's own human-readable serialized data strucutres to more compact binary
+formats.
+
+No specicial configuration is required.  If both extensions are enabled,
+memcache will automatically use the igbinary extension. If only one extension
+is enabled, memcache will automatically use that extension.
+
+You can optionally specify which extension is used by adding one of the
+following to your settings.php:
+
+  // Force memcache to use PHP's core serialize functions
+  $conf['memcache_serialize'] = 'serialize';
+
+  // Force memcache to use the igbinary serialize functions (if available)
+  $conf['memcache_serialize'] = 'igbinary';
+
+  // Force memcache to use the msgpack serialize functions (if available)
+  $conf['memcache_serialize'] = 'msgpack';
+
+To review which serialize function is being used, enable the memcache_admin
+module and visit admin/reports/memcache.
+
+IGBINARY:
+
+The igbinary project is maintained on GitHub:
+ - https://github.com/phadej/igbinary
+
+The official igbinary PECL extension can be found at:
+ - https://pecl.php.net/package/igbinary
+
+Version 2.0.1 or greater is recommended.
+
+MSGPACK:
+
+The msgpack project is maintained at:
+  - https://msgpack.org
+
+The official msgpack PECL extension can be found at:
+  - https://pecl.php.net/package/msgpack
+
+Version 2.0.2 or greater is recommended.
+
+## MAXIMUM LENGTHS ##
+
+If the length of your prefix + key + bin combine to be more than 250 characters,
+they will be automatically hashed. Memcache only supports key lengths up to 250
+bytes. You can optionally configure the hashing algorithm used, however sha1 was
+selected as the default because it performs quickly with minimal collisions.
+
+Visit http://www.php.net/manual/en/function.hash-algos.php to learn more about
+which hash algorithms are available.
+
+$conf['memcache_key_hash_algorithm'] = 'sha1';
+
+You can also tune the maximum key length BUT BE AWARE this doesn't affect
+memcached's server-side limitations -- this value is primarily exposed to allow
+you to further shrink the length of keys to optimize network performance.
+Specifying a length larger than 250 will almost certainly lead to problems
+unless you know what you're doing.
+
+$conf['memcache_key_max_length'] = 250;
+
+By default, the memcached server can store objects up to 1 MiB in size. It's
+possible to increase the memcached page size to support larger objects, but this
+can also lead to wasted memory. Alternatively, the Drupal memcache module splits
+these large objects into smaller pieces. By default, the Drupal memcache module
+splits objects into 1 MiB sized pieces. You can modify this with the following
+tunable to match any special server configuration you may have. NOTE: Increasing
+this value without making changes to your memcached server can result in
+failures to cache large items.
+
+(Note: 1 MiB = 1024 x 1024 = 1048576.)
+
+$conf['memcache_data_max_length'] = 1048576;
+
+It is generally undesirable to store excessively large objects in memcache as
+this can result in a performance penalty. Because of this, by default the Drupal
+memcache module logs any time an object is cached that has to be split into
+multiple pieces. If this is generating too many watchdog logs, you should first
+understand why these objects are so large and if anything can be done to make
+them smaller. If you determine that the large size is valid and is not causing
+you any unnecessary performance penalty, you can tune the following variable to
+minimize or disable this logging. Set the value to a positive integer to only
+log when an object is split into this many or more pieces. For example, if
+memcache_data_max_length is set to 1048576 and memcache_log_data_pieces is set
+to 5, watchdog logs will only be written when an object is split into 5 or more
+pieces (objects >4 MiB in size). Or, to to completely disable logging set
+memcache_log_data_pieces to 0 or FALSE.
+
+$conf['memcache_log_data_pieces'] = 2;
+
+## MULTIPLE SERVERS ##
+
+To use this module with multiple memcached servers, it is important that you set
+the hash strategy to consistent. This is controlled in the PHP extension, not
+the Drupal module.
+
+If using PECL memcache:
+Edit /etc/php.d/memcache.ini (path may changed based on package/distribution)
+and set the following:
+memcache.hash_strategy=consistent
+
+You need to reload apache httpd after making that change.
+
+If using PECL memcached:
+Memcached options can be controlled in settings.php.  The following setting is
+needed:
+$conf['memcache_options'] = array(
+  Memcached::OPT_DISTRIBUTION => Memcached::DISTRIBUTION_CONSISTENT,
+);
+
+## DEBUG LOGGING ##
+
+You can optionally enable debug logging by adding the following to your
+settings.php:
+  $conf['memcache_debug_log'] = '/path/to/file.log';
+
+By default, only the following memcache actions are logged: 'set', 'add',
+'delete', and 'flush'. If you'd like to also log 'get' and 'getMulti' actions,
+enble verbose logging:
+  $conf['memcache_debug_verbose'] = TRUE;
+
+This file needs to be writable by the web server (and/or by drush) or you will
+see lots of watchdog errors. You are responsible for ensuring that the debug log
+doesn't get too large. By default, enabling debug logging will write logs
+looking something like:
+
+  1484719570|add|semaphore|semaphore-memcache_system_list%3Acache_bootstrap|1
+  1484719570|set|cache_bootstrap|cache_bootstrap-system_list|1
+  1484719570|delete|semaphore|semaphore-memcache_system_list%3Acache_bootstrap|1
+
+The default log format is pipe delineated, containing the following fields:
+  timestamp|action|bin|cid|return code
+
+You can specify a custom log format by setting the memcache_debug_log_format
+variable. Supported variables that will be replaced in your format are:
+'!timestamp', '!action', '!bin', '!cid', and '!rc'.
+For example, the default log format (note that it includes a new line at the
+end) is:
+  $conf['memcache_debug_log_format'] = "!timestamp|!action|!bin|!cid|!rc\n";
+
+You can change the timestamp format by specifying a PHP date() format string in
+the memcache_debug_time_format variable. PHP date() formats are documented at
+http://php.net/manual/en/function.date.php. By default timestamps are written as
+a unix timestamp. For example:
+  $conf['memcache_debug_time_format'] = 'U';
+
+## TROUBLESHOOTING ##
+
+PROBLEM:
+ Error:
+  Failed to load required file memcache/dmemcache.inc
+ Or:
+ cache_backends not properly configured in settings.php, failed to load
+ required file memcache.inc
+
+SOLUTION:
+You need to enable memcache in settings.php. Search for "Example 1" above
+for a basic configuration example.
+
+PROBLEM:
+ Error:
+  PECL !extension version %version is unsupported. Please update to
+  %recommended or newer.
+
+SOLUTION:
+Upgrade to the latest available PECL extension release. Older PECL extensions
+have known bugs and cause a variety of problems when using the memcache module.
+
+PROBLEM:
+ Error:
+  Failed to connect to memcached server instance at <IP ADDRESS>.
+
+SOLUTION:
+Verify that the memcached daemon is running at the specified IP and PORT. To
+debug you can try to telnet directly to the memcache server from your web
+servers, example:
+   telnet localhost 11211
+
+PROBLEM:
+ Error:
+  Failed to store to then retrieve data from memcache.
+
+SOLUTION:
+Carefully review your settings.php configuration against the above
+documentation. This error simply does a cache_set followed by a cache_get
+and confirms that what is written to the cache can then be read back again.
+This test was added in the 7.x-1.1 release.
+
+The following code is what performs this test -- you can wrap this in a <?php
+tag and execute as a script with 'drush scr' to perform further debugging.
+
+        $cid = 'memcache_requirements_test';
+        $value = 'OK';
+        // Temporarily store a test value in memcache.
+        cache_set($cid, $value);
+        // Retreive the test value from memcache.
+        $data = cache_get($cid);
+        if (!isset($data->data) || $data->data !== $value) {
+          echo t('Failed to store to then retrieve data from memcache.');
+        }
+        else {
+          // Test a delete as well.
+          cache_clear_all($cid, 'cache');
+        }
+
+PROBLEM:
+ Error:
+  Unexpected failure when testing memcache configuration.
+
+SOLUTION:
+Be sure the memcache module is properly installed, and that your settings.php
+configuration is correct. This error means an exception was thrown when
+attempting to write to and then read from memcache.
+
+PROBLEM:
+ Error:
+  Failed to set key: Failed to set key: cache_page-......
+
+SOLUTION:
+Upgrade your PECL library to PECL package (2.2.1) (or higher).
+
+WARNING:
+Zlib compression at the php.ini level and Memcache conflict.
+See http://drupal.org/node/273824
+
+## MEMCACHE ADMIN ##
+
+A module offering a UI for memcache is included. It provides aggregated and
+per-page statistics for memcache.
+
+## Memcached PECL Extension Support
+
+We also support the Memcached PECL extension. This extension backends
+to libmemcached and allows you to use some of the newer advanced features in
+memcached 1.4.
+
+NOTE: It is important to realize that the memcache php.ini options do not impact
+the memcached extension, this new extension doesn't read in options that way.
+Instead, it takes options directly from Drupal. Because of this, you must
+configure memcached in settings.php. Please look here for possible options:
+
+http://us2.php.net/manual/en/memcached.constants.php
+
+An example configuration block is below, this block also illustrates our
+default options (selected through performance testing). These options will be
+set unless overridden in settings.php.
+
+  $conf['memcache_options'] = array(
+    Memcached::OPT_DISTRIBUTION => Memcached::DISTRIBUTION_CONSISTENT,
+  );
+
+These are as follows:
+
+ * Turn on consistent distribution, which allows you to add/remove servers
+   easily
+
+Other options you could experiment with:
+ + Memcached::OPT_COMPRESSION => FALSE,
+    * This disables compression in the Memcached extension. This may save some
+      CPU cost, but can result in significantly more data being transmitted and
+      stored. See: https://www.drupal.org/project/memcache/issues/2958403
+
+ + Memcached::OPT_BINARY_PROTOCOL => TRUE,
+    * This enables the Memcache binary protocol (only available in Memcached
+      1.4 and later). Note that some users have reported SLOWER performance
+      with this feature enabled. It should only be enabled on extremely high
+      traffic networks where memcache network traffic is a bottleneck.
+      Additional reading about the binary protocol:
+        http://code.google.com/p/memcached/wiki/MemcacheBinaryProtocol
+
+ + Memcached::OPT_TCP_NODELAY => TRUE,
+    * This enables the no-delay feature for connecting sockets; it's been
+      reported that this can speed up the Binary protocol (see above). This
+      tells the TCP stack to send packets immediately and without waiting for
+      a full payload, reducing per-packet network latency (disabling "Nagling").
+
+### Authentication
+
+#### Binary Protocol SASL Authentication
+
+SASL authentication can be enabled as documented here:
+  http://php.net/manual/en/memcached.setsaslauthdata.php
+  https://code.google.com/p/memcached/wiki/SASLHowto
+
+SASL authentication requires a memcached server with SASL support (version 1.4.3
+or greater built with --enable-sasl and started with the -S flag) and the PECL
+memcached client version 2.0.0 or greater also built with SASL support. Once
+these requirements are satisfied you can then enable SASL support in the Drupal
+memcache module by enabling the binary protocol and setting
+memcache_sasl_username and memcache_sasl_password in settings.php. For example:
+
+  $conf['memcache_options'] = array(
+    Memcached::OPT_BINARY_PROTOCOL => TRUE,
+  );
+  $conf['memcache_sasl_username'] = 'yourSASLUsername';
+  $conf['memcache_sasl_password'] = 'yourSASLPassword';
+
+#### ASCII Protocol Authentication
+
+If you do not want to enable the binary protocol, you can instead enable
+token authentication with the default ASCII protocol.
+
+ASCII protocol authentication requires Memcached version 1.5.15 or greater
+started with the -Y flag, and the PECL memcached client. It was originally
+documented in the memcached 1.5.15 release notes:
+  https://github.com/memcached/memcached/wiki/ReleaseNotes1515
+
+While it will work with 1.5.15 or greater, it's strongly recommended you
+use memcached 1.6.4 or greater due to the following bug fix:
+  https://github.com/memcached/memcached/wiki/ReleaseNotes164
+
+Additional detail about this feature can be found in the protocol documentation:
+  https://github.com/memcached/memcached/blob/master/doc/protocol.txt
+
+All your memcached servers need to be started with the -Y option to specify
+a local path to an authfile which can contain up to 8 "username:pasword"
+pairs, any of which can be used for authentication. For example, a simple
+authfile may look as follows:
+
+  foo:bar
+
+You can then configure your website to authenticate with this username and
+password as follows:
+
+  $conf['memcache_ascii_auth'] = 'foo bar';
+
+Enabling ASCII protocol authentication during load testing resulted in less than
+1% overhead.
+
+## Amazon Elasticache
+
+You can use the Drupal Memcache module to talk with Amazon Elasticache, but to
+enable Automatic Discovery you must use Amazon's forked version of the PECL
+Memcached extension with Dynamic Client Mode enabled.
+
+Their PECL Memcached fork is maintained on GitHub:
+ - https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-php
+
+If you are using PHP 7 you need to select the php7 branch of their project.
+
+Once the extension is installed, you can enable Dynamic Client Mode as follows:
+
+  $conf['memcache_options'] = array(
+    Memcached::OPT_DISTRIBUTION => Memcached::DISTRIBUTION_CONSISTENT,
+    Memcached::OPT_CLIENT_MODE  => Memcached::DYNAMIC_CLIENT_MODE,
+  );
+
+You then configure the module normally. Amazon explains:
+  "If you use Automatic Discovery, you can use the cluster's Configuration
+   Endpoint to configure your Memcached client."
+
+The Configuration Endpoint must have 'cfg' in the name or it won't work. Further
+documentation can be found here:
+http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/Endpoints.html
+
+If you don't want to use Automatic Discovery you don't need to install the
+forked PECL extension, Amazon explains:
+  "If you don't use Automatic Discovery, you must configure your client to use
+   the individual node endpoints for reads and writes. You must also keep track
+   of them as you add and remove nodes."

--- a/html/sites/all/modules/contrib/memcache/dmemcache.inc
+++ b/html/sites/all/modules/contrib/memcache/dmemcache.inc
@@ -1,0 +1,1552 @@
+<?php
+
+/**
+ * @file
+ * A memcache API for Drupal.
+ *
+ * This file contains core dmemcache functions required by:
+ *   memcache.inc
+ *   memcache-lock.inc
+ *   memcache-lock-code.inc
+ */
+
+define('MEMCACHED_E2BIG', 37);
+define('MEMCACHED_CLIENT_ERROR', 9);
+define('MEMCACHED_SERVER_TIMED_OUT', 47);
+define('DRUPAL_MEMCACHE_ASCII_AUTH_KEY', 'drupal:memcache:ascii:auth:key');
+define('DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY', 'drupal:memcache:ascii:auth:lifetime:key');
+
+global $_dmemcache_stats;
+$_dmemcache_stats = array('all' => array(), 'ops' => array());
+
+/**
+ * Place an item into memcache.
+ *
+ * @param string $key
+ *   The string with which you will retrieve this item later.
+ * @param mixed $value
+ *   The item to be stored.
+ * @param int $exp
+ *   Parameter expire is expiration time in seconds. If it's 0, the item never
+ *   expires (but memcached server doesn't guarantee this item to be stored all
+ *   the time, it could be deleted from the cache to make place for other
+ *   items).
+ * @param string $bin
+ *   The name of the Drupal subsystem that is making this call. Examples could
+ *   be 'cache', 'alias', 'taxonomy term' etc. It is possible to map different
+ *   $bin values to different memcache servers.
+ * @param object $mc
+ *   Optionally pass in the memcache object.  Normally this value is determined
+ *   automatically based on the bin the object is being stored to.
+ *
+ * @return bool
+ *   TRUE on succes, FALSE otherwise.
+ */
+function dmemcache_set($key, $value, $exp = 0, $bin = 'cache', $mc = NULL) {
+  $collect_stats = dmemcache_stats_init();
+
+  $full_key = dmemcache_key($key, $bin);
+
+  $rc = FALSE;
+  if ($mc || ($mc = dmemcache_object($bin))) {
+    if ($mc instanceof Memcached) {
+      $rc = $mc->set($full_key, $value, $exp);
+      if (empty($rc)) {
+        if ($mc->getResultCode() == MEMCACHED_CLIENT_ERROR && _dmemcache_ensure_ascii_auth($full_key, $mc)) {
+          $rc = $mc->set($full_key, $value, $exp);
+        }
+
+        // If there was a MEMCACHED_E2BIG error, split the value into pieces
+        // and cache them individually.
+        if ($mc->getResultCode() == MEMCACHED_E2BIG) {
+          $rc = _dmemcache_set_pieces($key, $value, $exp, $bin, $mc);
+        }
+      }
+    }
+    else {
+      // The PECL Memcache library throws an E_NOTICE level error, which
+      // $php_errormsg doesn't catch, so we need to log it ourselves.
+      // Catch it with our own error handler.
+      drupal_static_reset('_dmemcache_error_handler');
+      set_error_handler('_dmemcache_error_handler');
+      $rc = $mc->set($full_key, $value, MEMCACHE_COMPRESSED, $exp);
+      // Restore the Drupal error handler.
+      restore_error_handler();
+      if (empty($rc)) {
+        // If the object was too big, split the value into pieces and cache
+        // them individually.
+        $dmemcache_errormsg = &drupal_static('_dmemcache_error_handler');
+        if (!empty($dmemcache_errormsg) && (strpos($dmemcache_errormsg, 'SERVER_ERROR object too large for cache') !== FALSE || strpos($dmemcache_errormsg, 'SERVER_ERROR out of memory storing object') !== FALSE)) {
+          $rc = _dmemcache_set_pieces($key, $value, $exp, $bin, $mc);
+        }
+      }
+    }
+  }
+
+  if ($collect_stats) {
+    dmemcache_stats_write('set', $bin, array($full_key => $rc));
+  }
+
+  _dmemcache_write_debug('set', $bin, $full_key, $rc);
+
+  return $rc;
+}
+
+/**
+ * A temporary error handler which keeps track of the most recent error.
+ */
+function _dmemcache_error_handler($errno, $errstr) {
+  $dmemcache_errormsg = &drupal_static(__FUNCTION__);
+  $dmemcache_errormsg = $errstr;
+  return TRUE;
+}
+
+/**
+ *  Split a large item into pieces and place them into memcache
+ *
+ * @param string $key
+ *   The string with which you will retrieve this item later.
+ * @param mixed $value
+ *   The item to be stored.
+ * @param int $exp
+ *   (optional) Expiration time in seconds. If it's 0, the item never expires
+ *   (but memcached server doesn't guarantee this item to be stored all the
+ *   time, it could be deleted from the cache to make place for other items).
+ * @param string $bin
+ *   (optional) The name of the Drupal subsystem that is making this call.
+ *   Examples could be 'cache', 'alias', 'taxonomy term' etc. It is possible to
+ *   map different $bin values to different memcache servers.
+ * @param object $mc
+ *   (optional) The memcache object. Normally this value is
+ *   determined automatically based on the bin the object is being stored to.
+ *
+ * @return bool
+ */
+function _dmemcache_set_pieces($key, $value, $exp = 0, $bin = 'cache', $mc = NULL) {
+  static $recursion = 0;
+  if (!empty($value->multi_part_data) || !empty($value->multi_part_pieces)) {
+    // Prevent an infinite loop.
+    return FALSE;
+  }
+
+  // Recursion happens when __dmemcache_piece_cache outgrows the largest
+  // memcache slice (1 MiB by default) -- prevent an infinite loop and later
+  // generate a watchdog error.
+  if ($recursion) {
+    return FALSE;
+  }
+  $recursion++;
+
+  $full_key = dmemcache_key($key);
+
+  // Cache the name of this key so if it is deleted later we know to also
+  // delete the cache pieces.
+  if (!dmemcache_piece_cache_set($full_key, $exp)) {
+    // We're caching a LOT of large items. Our piece_cache has exceeded the
+    // maximum memcache object size (default of 1 MiB).
+    $piece_cache = &drupal_static('dmemcache_piece_cache', array());
+    register_shutdown_function('watchdog', 'memcache', 'Too many over-sized cache items (!count) has caused the dmemcache_piece_cache to exceed the maximum memcache object size (default of 1 MiB). Now relying on memcache auto-expiration to eventually clean up over-sized cache pieces upon deletion.', array('!count' => count($piece_cache)), WATCHDOG_ERROR);
+  }
+
+  if (variable_get('memcache_log_data_pieces', 2)) {
+    timer_start('memcache_split_data');
+  }
+
+  // We need to split the item into pieces, so convert it into a string.
+  if (is_string($value)) {
+    $data = $value;
+    $serialized = FALSE;
+  }
+  else {
+    $serialize_function = dmemcache_serialize();
+    $data = $serialize_function($value);
+    $serialized = TRUE;
+  }
+
+  // Account for any metadata stored alongside the data.
+  $max_len = variable_get('memcache_data_max_length', 1048576) - (512 + strlen($full_key));
+  $pieces = str_split($data, $max_len);
+
+  $piece_count = count($pieces);
+
+  // Create a placeholder item containing data about the pieces.
+  $cache = new stdClass;
+  // $key gets run through dmemcache_key() later inside dmemcache_set().
+  $cache->cid = $key;
+  $cache->created = REQUEST_TIME;
+  $cache->expire = $exp;
+  $cache->data = new stdClass;
+  $cache->data->serialized = $serialized;
+  $cache->data->piece_count = $piece_count;
+  $cache->multi_part_data = TRUE;
+  $result = dmemcache_set($cache->cid, $cache, $exp, $bin, $mc);
+
+  // Create a cache item for each piece of data.
+  foreach ($pieces as $id => $piece) {
+    $cache = new stdClass;
+    $cache->cid = _dmemcache_key_piece($key, $id);
+    $cache->created = REQUEST_TIME;
+    $cache->expire = $exp;
+    $cache->data = $piece;
+    $cache->multi_part_piece = TRUE;
+
+    $result &= dmemcache_set($cache->cid, $cache, $exp, $bin, $mc);
+  }
+
+  if (variable_get('memcache_log_data_pieces', 2) && $piece_count >= variable_get('memcache_log_data_pieces', 2)) {
+    if (function_exists('format_size')) {
+      $data_size = format_size(strlen($data));
+    }
+    else {
+      $data_size = number_format(strlen($data)) . ' byte';
+    }
+    register_shutdown_function('watchdog', 'memcache', 'Spent !time ms splitting !bytes object into !pieces pieces, cid = !key', array('!time' => timer_read('memcache_split_data'), '!bytes' => $data_size, '!pieces' => $piece_count, '!key' => dmemcache_key($key, $bin)), WATCHDOG_WARNING);
+  }
+
+  $recursion--;
+
+  // TRUE if all pieces were saved correctly.
+  return $result;
+}
+
+/**
+ * Add an item into memcache.
+ *
+ * @param string $key
+ *   The string with which you will retrieve this item later.
+ * @param mixed $value
+ *   The item to be stored.
+ * @param int $exp
+ *   (optional) Expiration time in seconds. If it's 0, the item never expires
+ *   (but memcached server doesn't guarantee this item to be stored all the
+ *   time, it could be deleted from the cache to make place for other items).
+ * @param string $bin
+ *   (optional) The name of the Drupal subsystem that is making this call.
+ *   Examples could be 'cache', 'alias', 'taxonomy term' etc. It is possible
+ *   to map different $bin values to different memcache servers.
+ * @param object $mc
+ *   (optional) The memcache object. Normally this value is
+ *   determined automatically based on the bin the object is being stored to.
+ * @param bool $flag
+ *   (optional) If using the older memcache PECL extension as opposed to the
+ *   newer memcached PECL extension, the MEMCACHE_COMPRESSED flag can be set
+ *   to use zlib to store a compressed copy of the item.  This flag option is
+ *   completely ignored when using the newer memcached PECL extension.
+ *
+ * @return bool
+ *   FALSE if placing the item into memcache failed.
+ */
+function dmemcache_add($key, $value, $exp = 0, $bin = 'cache', $mc = NULL, $flag = FALSE) {
+  $collect_stats = dmemcache_stats_init();
+
+  $full_key = dmemcache_key($key, $bin);
+
+  $rc = FALSE;
+  if ($mc || ($mc = dmemcache_object($bin))) {
+    if ($mc instanceof Memcached) {
+      $rc = $mc->add($full_key, $value, $exp);
+      if (empty($rc) && $mc->getResultCode() == MEMCACHED_CLIENT_ERROR && _dmemcache_ensure_ascii_auth($full_key, $mc)) {
+        $rc = $mc->add($full_key, $value, $exp);
+      }
+    }
+    else {
+      $rc = $mc->add($full_key, $value, $flag, $exp);
+    }
+  }
+
+  if ($collect_stats) {
+    dmemcache_stats_write('add', $bin, array($full_key => $rc));
+  }
+
+  _dmemcache_write_debug('add', $bin, $full_key, $rc);
+
+  return $rc;
+}
+
+/**
+ * Retrieve a value from the cache.
+ *
+ * @param string $key
+ *   The key with which the item was stored.
+ * @param string $bin
+ *   The bin in which the item was stored.
+ *
+ * @return mixed
+ *   The item which was originally saved or FALSE
+ */
+function dmemcache_get($key, $bin = 'cache', $mc = NULL) {
+  static $memcache_ascii_auth = NULL;
+
+  $collect_stats = dmemcache_stats_init();
+
+  $result = FALSE;
+
+  $full_key = dmemcache_key($key, $bin);
+  if ($mc || $mc = dmemcache_object($bin)) {
+    $track_errors = ini_set('track_errors', '1');
+    $php_errormsg = '';
+
+    $result = @$mc->get($full_key);
+    if (empty($result)) {
+      if (!isset($memcache_ascii_auth)) {
+        $memcache_ascii_auth = _dmemcache_use_ascii_auth();
+      }
+      if ($memcache_ascii_auth) {
+        // As sets are costly we first check that the server is not authorized first.
+        $rc = $mc->getByKey($full_key, DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY);
+        if (empty($rc) && _dmemcache_ensure_ascii_auth($full_key, $mc)) {
+          $result = @$mc->get($full_key);
+        }
+      }
+    }
+
+    // This is a multi-part value.
+    if (is_object($result) && !empty($result->multi_part_data)) {
+      $result = _dmemcache_get_pieces($result->data, $result->cid, $bin, $mc);
+    }
+
+    if (!empty($php_errormsg)) {
+      register_shutdown_function('watchdog', 'memcache', 'Exception caught in dmemcache_get: !msg', array('!msg' => $php_errormsg), WATCHDOG_WARNING);
+      $php_errormsg = '';
+    }
+    ini_set('track_errors', $track_errors);
+  }
+
+  if ($collect_stats) {
+    dmemcache_stats_write('get', $bin, array($full_key => (bool) $result));
+  }
+
+  _dmemcache_write_debug('get', $bin, $full_key, (bool) $result);
+
+  return $result;
+}
+
+/**
+ * Retrieve a value from the cache.
+ *
+ * @param $item
+ *   The placeholder cache item from _dmemcache_set_pieces().
+ * @param $key
+ *   The key with which the item was stored.
+ * @param string $bin
+ *   (optional) The bin in which the item was stored.
+ * @param object $mc
+ *   (optional) The memcache object. Normally this value is
+ *   determined automatically based on the bin the object is being stored to.
+ *
+ * @return object|bool
+ *   The item which was originally saved or FALSE.
+ */
+function _dmemcache_get_pieces($item, $key, $bin = 'cache', $mc = NULL) {
+  // Create a list of keys for the pieces of data.
+  for ($id = 0; $id < $item->piece_count; $id++) {
+    $keys[] = _dmemcache_key_piece($key, $id);
+  }
+
+  // Retrieve all the pieces of data and append them together.
+  $pieces = dmemcache_get_multi($keys, $bin, $mc);
+  $data = '';
+  foreach ($pieces as $piece) {
+    // The piece may be NULL if it didn't exist in memcache. If so,
+    // we have to just return false for the entire set because we won't
+    // be able to reconstruct the original data without all the pieces.
+    if (!$piece) {
+      return FALSE;
+    }
+    $data .= $piece->data;
+  }
+  unset($pieces);
+
+  // If necessary unserialize the item.
+  if (empty($item->serialized)) {
+    return $data;
+  }
+  else {
+    $unserialize_function = dmemcache_unserialize();
+    return $unserialize_function($data);
+  }
+}
+
+/**
+ * Generates a key name for a multi-part data piece based on the sequence ID.
+ *
+ * @param int $id
+ *   The sequence ID of the data piece.
+ * @param int $key
+ *   The original CID of the cache item.
+ *
+ * @return string
+ */
+function _dmemcache_key_piece($key, $id) {
+  return dmemcache_key('_multi'. (string)$id . "-$key");
+}
+
+/**
+ * Retrieve multiple values from the cache.
+ *
+ * @param array $keys
+ *   The keys with which the items were stored.
+ * @param string $bin
+ *   The bin in which the item was stored.
+ *
+ * @return mixed
+ *   An array keyed by $keys with the items requested or
+ *   NULL values if the data was not present.
+ */
+function dmemcache_get_multi($keys, $bin = 'cache', $mc = NULL) {
+  static $memcache_ascii_auth = NULL;
+
+  $collect_stats = dmemcache_stats_init();
+  $multi_stats = array();
+
+  $full_keys = array();
+
+  foreach ($keys as $key => $cid) {
+    $full_key = dmemcache_key($cid, $bin);
+    $full_keys[$cid] = $full_key;
+
+    if ($collect_stats) {
+      $multi_stats[$full_key] = FALSE;
+    }
+  }
+
+  $results = array();
+  if ($mc || ($mc = dmemcache_object($bin))) {
+    if ($mc instanceof Memcached) {
+      if (PHP_MAJOR_VERSION >= 7) {
+        // See https://www.drupal.org/node/2728427
+        $results = $mc->getMulti($full_keys, Memcached::GET_PRESERVE_ORDER);
+      }
+      else {
+        $cas_tokens = NULL;
+        $results = $mc->getMulti($full_keys, $cas_tokens, Memcached::GET_PRESERVE_ORDER);
+      }
+
+      // If $results is FALSE, convert it to an empty array.
+      if (!$results) {
+        $results = array();
+      }
+
+      if (!isset($memcache_ascii_auth)) {
+        $memcache_ascii_auth = _dmemcache_use_ascii_auth();
+      }
+
+      // Find out which results have values and which have not.
+      if ($memcache_ascii_auth && count(array_filter($results)) < count($full_keys)) {
+        // Convert empty results to the full keys with value of NULL.
+        if (empty($results)) {
+          $results = array_fill_keys($full_keys, NULL);
+        }
+        $new_results = _dmemcache_get_multi_2nd_chance_ascii_auth($results, $mc);
+        foreach ($new_results as $full_key => $value) {
+          $results[$full_key] = $value;
+        }
+      }
+    }
+    elseif ($mc instanceof Memcache) {
+      $track_errors = ini_set('track_errors', '1');
+      $php_errormsg = '';
+
+      $results = @$mc->get($full_keys);
+
+      if (!empty($php_errormsg)) {
+        register_shutdown_function('watchdog', 'memcache', 'Exception caught in dmemcache_get_multi: !msg', array('!msg' => $php_errormsg), WATCHDOG_WARNING);
+        $php_errormsg = '';
+      }
+      ini_set('track_errors', $track_errors);
+
+      // Order is not guaranteed, map responses to order of requests.
+      if (is_array($results)) {
+        $keys = array_fill_keys($full_keys, NULL);
+        $results = array_merge($keys, $results);
+      }
+    }
+  }
+
+  // If $results is FALSE, convert it to an empty array.
+  if (!$results) {
+    $results = array();
+    $keys = array_fill_keys($full_keys, NULL);
+    $results = array_merge($keys, $results);
+    _dmemcache_write_debug('getMulti', $bin, implode(',', $full_keys), FALSE);
+  }
+
+  if ($collect_stats) {
+    foreach ($multi_stats as $key => $value) {
+      $multi_stats[$key] = isset($results[$key]) ? TRUE : FALSE;
+    }
+  }
+
+  // Convert the full keys back to the cid.
+  $cid_results = array();
+  $cid_lookup = array_flip($full_keys);
+  foreach ($results as $key => $value) {
+    // This is a multi-part value.
+    if (is_object($value) && !empty($value->multi_part_data)) {
+      $value = _dmemcache_get_pieces($value->data, $value->cid, $bin, $mc);
+    }
+    $cid_results[$cid_lookup[$key]] = $value;
+    _dmemcache_write_debug('getMulti', $bin, $key, TRUE);
+  }
+
+  if ($collect_stats) {
+    dmemcache_stats_write('getMulti', $bin, $multi_stats);
+  }
+
+  return $cid_results;
+}
+
+/**
+ * Deletes an item from the cache.
+ *
+ * @param string $key
+ *   The key with which the item was stored.
+ * @param string $bin
+ *   The bin in which the item was stored.
+ *
+ * @return bool
+ *   Returns TRUE on success or FALSE on failure.
+ */
+function dmemcache_delete($key, $bin = 'cache', $mc = NULL) {
+  $collect_stats = dmemcache_stats_init();
+
+  $full_keys = dmemcache_key($key, $bin, TRUE);
+
+  $rc = FALSE;
+  if ($mc || ($mc = dmemcache_object($bin))) {
+    foreach ($full_keys as $fk) {
+      $rc = $mc->delete($fk, 0);
+      if (empty($rc) && $mc instanceof Memcached && _dmemcache_ensure_ascii_auth($fk, $mc)) {
+        $rc = $mc->delete($fk, 0);
+      }
+
+      if ($rc) {
+        // If the delete succeeded, we now check to see if this item has
+        //  multiple pieces also needing to be cleaned up. If the delete failed,
+        // we assume these keys have already expired or been deleted (memcache
+        // will auto-expire eventually if we're wrong).
+        if ($piece_cache = dmemcache_piece_cache_get($fk)) {
+          // First, remove from the piece_cache so we don't try and delete it
+          // again in another thread, then delete the actual cache data pieces.
+          dmemcache_piece_cache_set($fk, NULL);
+          $next_id = 0;
+          do {
+            if ($inner_rc) {
+              _dmemcache_write_debug("delete", $bin, $full_key, $inner_rc);
+            }
+            // Generate the cid of the next data piece.
+            $piece_key = _dmemcache_key_piece($key, $next_id);
+            $full_key = dmemcache_key($piece_key, $bin);
+            $next_id++;
+
+            // Keep deleting pieces until the operation fails. We accept that
+            // this could lead to orphaned pieces as memcache will auto-expire
+            // them eventually.
+          } while ($inner_rc = $mc->delete($full_key, 0));
+          _dmemcache_write_debug("delete", $bin, $full_key, $inner_rc);
+
+          // Perform garbage collection for keys memcache has auto-expired. If
+          // we don't do this, this variable could grow over enough time as a
+          // slow memory leak.
+          // @todo: Consider moving this to hook_cron() and requiring people to
+          // enable the memcache module.
+          timer_start('memcache_gc_piece_cache');
+          $gc_counter = 0;
+          $piece_cache = &drupal_static('dmemcache_piece_cache', array());
+          foreach ($piece_cache as $cid => $expires) {
+            if (REQUEST_TIME > $expires) {
+              $gc_counter++;
+              dmemcache_piece_cache_set($cid, NULL);
+            }
+          }
+          if ($gc_counter) {
+            register_shutdown_function('watchdog', 'memcache', 'Spent !time ms in garbage collection cleaning !count stale keys from the dmemcache_piece_cache.', array('!time' => timer_read('memcache_gc_piece_cache'), '!count' => $gc_counter), WATCHDOG_WARNING);
+          }
+        }
+      }
+      if ($collect_stats) {
+        dmemcache_stats_write('delete', $bin, array($fk => $rc));
+      }
+      _dmemcache_write_debug('delete', $bin, $fk, $rc);
+    }
+  }
+
+  return $rc;
+}
+
+/**
+ * Flush all stored items.
+ *
+ * Immediately invalidates all existing items. dmemcache_flush doesn't actually
+ * free any resources, it only marks all the items as expired, so occupied
+ * memory will be overwritten by new items.
+ *
+ * @param string $bin
+ *   The bin to flush. Note that this will flush all bins mapped to the same
+ *   server as $bin. There is no way at this time to empty just one bin.
+ *
+ * @return bool
+ *   Returns TRUE on success or FALSE on failure.
+ */
+function dmemcache_flush($bin = 'cache', $mc = NULL) {
+  $collect_stats = dmemcache_stats_init();
+
+  $rc = FALSE;
+  if ($mc || ($mc = dmemcache_object($bin))) {
+    $rc = $mc->flush();
+    // If a composite call fails, we need to reset the authentication
+    // for the whole mc object.
+    if (empty($rc) && _dmemcache_reset_ascii_auth($mc)) {
+      $mc->flush();
+    }
+  }
+
+  if ($collect_stats) {
+    dmemcache_stats_write('flush', $bin, array('' => $rc));
+  }
+
+  _dmemcache_write_debug('flush', $bin, '', $rc);
+
+  return $rc;
+}
+
+/**
+ * Retrieves statistics recorded during memcache operations.
+ *
+ * @param string $stats_bin
+ *   The bin to retrieve statistics for.
+ * @param string $stats_type
+ *   The type of statistics to retrieve when using the Memcache extension.
+ * @param bool $aggregate
+ *   Whether to aggregate statistics.
+ *
+ * @return array
+ *   The statistics
+ */
+function dmemcache_stats($stats_bin = 'cache', $stats_type = 'default', $aggregate = FALSE) {
+  $memcache_bins = variable_get('memcache_bins', array('cache' => 'default'));
+  // The stats_type can be over-loaded with an integer slab id, if doing a
+  // cachedump.  We know we're doing a cachedump if $slab is non-zero.
+  $slab = (int) $stats_type;
+  $stats = array();
+
+  foreach ($memcache_bins as $bin => $target) {
+    if ($stats_bin == $bin) {
+      if ($mc = dmemcache_object($bin)) {
+        if ($mc instanceof Memcached) {
+          $stats[$bin] = $mc->getStats();
+          // If a composite call fails, we need to reset the authentication
+          // for the whole mc object.
+          if (empty($stats[$bin]) && _dmemcache_reset_ascii_auth($mc)) {
+            $stats[$bin] = $mc->getStats();
+          }
+        }
+        // The PHP Memcache extension 3.x version throws an error if the stats
+        // type is NULL or not in {reset, malloc, slabs, cachedump, items,
+        // sizes}. If $stats_type is 'default', then no parameter should be
+        // passed to the Memcache memcache_get_extended_stats() function.
+        elseif ($mc instanceof Memcache) {
+          if ($stats_type == 'default' || $stats_type == '') {
+            $rc = $mc->getExtendedStats();
+            if (is_array($rc)) {
+              foreach ($rc as $server => $data) {
+                if (empty($data)) {
+                  unset($rc[$server]);
+                }
+              }
+              if (!empty($rc)) {
+                $stats[$bin] = $rc;
+              }
+            }
+          }
+          // If $slab isn't zero, then we are dumping the contents of a
+          // specific cache slab.
+          elseif (!empty($slab)) {
+            $stats[$bin] = $mc->getStats('cachedump', $slab);
+          }
+          else {
+            $stats[$bin] = $mc->getExtendedStats($stats_type);
+          }
+        }
+      }
+    }
+  }
+  // Optionally calculate a sum-total for all servers in the current bin.
+  if ($aggregate) {
+    foreach ($stats as $bin => $servers) {
+      if (is_array($servers)) {
+        foreach ($servers as $server) {
+          if (is_array($server)) {
+            foreach ($server as $key => $value) {
+              if (is_numeric($value)) {
+                if (isset($stats[$bin]['total'][$key])) {
+                  $stats[$bin]['total'][$key] += $value;
+                }
+                else {
+                  $stats[$bin]['total'][$key] = $value;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return $stats;
+}
+
+/**
+ * Determine which memcache extension to use: memcache or memcached.
+ *
+ * By default prefer the 'Memcache' PHP extension, though the default can be
+ * overridden by setting memcache_extension in settings.php.
+ */
+function dmemcache_extension() {
+  static $extension = NULL;
+  if ($extension === NULL) {
+    // If an extension is specified in settings.php, use that when available.
+    $preferred = variable_get('memcache_extension', NULL);
+    if (isset($preferred) && class_exists($preferred, FALSE)) {
+      $extension = ucfirst(strtolower($preferred));
+    }
+    // If no extension is set, default to Memcache.
+    elseif (class_exists('Memcache', FALSE)) {
+      $extension = 'Memcache';
+    }
+    elseif (class_exists('Memcached', FALSE)) {
+      $extension = 'Memcached';
+    }
+    else {
+      $extension = FALSE;
+    }
+  }
+  return $extension;
+}
+
+/**
+ * Determine which serialize extension to use: serialize (none), igbinary,
+ * or msgpack.
+ *
+ * By default we prefer the igbinary extension, then the msgpack extension,
+ * then the core serialize functions. This can be overridden in settings.php.
+ */
+function dmemcache_serialize_extension() {
+  static $extension = NULL;
+  if ($extension === NULL) {
+    $preferred = strtolower(variable_get('memcache_serialize', NULL));
+    // Fastpath if we're forcing php's own serialize function.
+    if ($preferred == 'serialize') {
+      $extension = $preferred;
+    }
+    // Otherwise, find an available extension favoring configuration.
+    else {
+      $igbinary_available = extension_loaded('igbinary');
+      $msgpack_available = extension_loaded('msgpack');
+      if ($preferred == 'igbinary' && $igbinary_available) {
+        $extension = $preferred;
+      }
+      elseif ($preferred == 'msgpack' && $msgpack_available) {
+        $extension = $preferred;
+      }
+      else {
+        // No (valid) serialize extension specified, try igbinary.
+        if ($igbinary_available) {
+          $extension = 'igbinary';
+        }
+        // Next try msgpack.
+        else if ($msgpack_available) {
+          $extension = 'msgpack';
+        }
+        // Finally fall back to core serialize.
+        else {
+          $extension = 'serialize';
+        }
+      }
+    }
+  }
+  return $extension;
+}
+
+/**
+ * Return proper serialize function.
+ */
+function dmemcache_serialize() {
+  switch (dmemcache_serialize_extension()) {
+    case 'igbinary':
+      return 'igbinary_serialize';
+    case 'msgpack':
+      return 'msgpack_pack';
+    default:
+      return 'serialize';
+  }
+}
+
+/**
+ * Return proper unserialize function.
+ */
+function dmemcache_unserialize() {
+  switch (dmemcache_serialize_extension()) {
+    case 'igbinary':
+      return 'igbinary_unserialize';
+    case 'msgpack':
+      return 'msgpack_unpack';
+    default:
+      return 'unserialize';
+  }
+}
+
+/**
+ * Return a new memcache instance.
+ */
+function dmemcache_instance($bin = 'cache') {
+  static $error = FALSE;
+  $extension = dmemcache_extension();
+  if ($extension == 'Memcache') {
+    return new Memcache();
+  }
+  elseif ($extension == 'Memcached') {
+    if (variable_get('memcache_persistent', TRUE)) {
+      $memcache = new Memcached($bin);
+    }
+    else {
+      $memcache = new Memcached;
+    }
+    $default_opts = array(
+      Memcached::OPT_DISTRIBUTION => Memcached::DISTRIBUTION_CONSISTENT,
+    );
+    foreach ($default_opts as $key => $value) {
+      $memcache->setOption($key, $value);
+    }
+    // See README.txt for setting custom Memcache options when using the
+    // memcached PECL extension.
+    $memconf = variable_get('memcache_options', array());
+    foreach ($memconf as $key => $value) {
+      $memcache->setOption($key, $value);
+    }
+    if (($sasl_username = variable_get('memcache_sasl_username', '')) && ($sasl_password = variable_get('memcache_sasl_password', ''))) {
+      $memcache->setSaslAuthData($sasl_username, $sasl_password);
+    }
+    return $memcache;
+  }
+  else {
+    if (!$error) {
+      register_shutdown_function('watchdog', 'memcache', 'You must enable the PHP <a href="http://php.net/manual/en/book.memcache.php">memcache</a> (recommended) or <a href="http://php.net/manual/en/book.memcached.php">memcached</a> extension to use memcache.inc.', array(), WATCHDOG_ERROR);
+      $error = TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/**
+ * Initiate a connection to memcache.
+ *
+ * @param object $memcache
+ *   A memcache instance obtained through dmemcache_instance.
+ * @param string $server
+ *   A server string of the format "localhost:11211" or
+ *   "unix:///path/to/socket".
+ * @param integer $weight
+ *   Weighted probability of talking to this server.
+ *
+ * @return bool
+ *   TRUE or FALSE if connection was successful.
+ */
+function dmemcache_connect($memcache, $server, $weight) {
+  static $memcache_persistent = NULL;
+  static $memcache_ascii_auth = NULL;
+
+  $extension = dmemcache_extension();
+
+  @list($host, $port) = explode(':', trim($server));
+  if (empty($host)) {
+    register_shutdown_function('watchdog', 'memcache', 'You have specified an invalid address of "!server" in settings.php. Please review README.txt for proper configuration.', array('!server' => $server, '!ip' => t('127.0.0.1:11211'), '!host' => t('localhost:11211'), '!socket' => t('unix:///path/to/socket')), WATCHDOG_WARNING);
+  }
+
+  if (!isset($memcache_persistent)) {
+    $memcache_persistent = variable_get('memcache_persistent', TRUE);
+  }
+  if (!isset($memcache_ascii_auth)) {
+    $memcache_ascii_auth = _dmemcache_use_ascii_auth();
+  }
+
+  $port_error = FALSE;
+  if ($extension == 'Memcache') {
+    // Support unix sockets of the format 'unix:///path/to/socket'.
+    if ($host == 'unix') {
+      // Use full protocol and path as expected by Memcache extension.
+      $host = $server;
+      $port = 0;
+    }
+    else if (!isset($port)) {
+      $port_error = TRUE;
+    }
+  }
+  elseif ($extension == 'Memcached') {
+    // Support unix sockets of the format 'unix:///path/to/socket'.
+    if ($host == 'unix') {
+      // Strip 'unix://' as expected by Memcached extension.
+      $host = substr($server, 7);
+      $port = 0;
+    }
+    else if (!isset($port)) {
+      $port_error = TRUE;
+    }
+  }
+
+  if ($port_error) {
+    register_shutdown_function('watchdog', 'memcache', 'You have specified an invalid address of "!server" in settings.php which does not include a port. Please review README.txt for proper configuration. You must specify both a server address and port such as "!ip" or "!host", or a unix socket such as "!socket".', array('!server' => $server, '!ip' => t('127.0.0.1:11211'), '!host' => t('localhost:11211'), '!socket' => t('unix:///path/to/socket')), WATCHDOG_WARNING);
+  }
+
+  if ($extension == 'Memcache') {
+    $rc = $memcache->addServer($host, $port, $memcache_persistent, $weight);
+  }
+  elseif ($extension == 'Memcached') {
+    $match = FALSE;
+    if ($memcache_persistent) {
+      $servers = $memcache->getServerList();
+      foreach ($servers as $s) {
+        if ($s['host'] == $host && $s['port'] == $port) {
+          $match = TRUE;
+          break;
+        }
+      }
+    }
+    if (!$match) {
+      $rc = $memcache->addServer($host, $port);
+      if ($rc && $memcache_ascii_auth) {
+        $rc = _dmemcache_ascii_authenticate_server($host, $port, $memcache);
+      }
+    }
+    else {
+      $rc = TRUE;
+    }
+  }
+  else {
+    $rc = FALSE;
+  }
+  return $rc;
+}
+
+/**
+ * Close the connection to the memcache instance.
+ */
+function dmemcache_close($memcache) {
+  $extension = dmemcache_extension();
+  if ($extension == 'Memcache' && $memcache instanceof Memcache) {
+    $rc = @$memcache->close;
+  }
+  elseif ($extension == 'Memcached' && $memcache instanceof Memcached) {
+    $rc = @$memcache->quit;
+  }
+  else {
+    $rc = FALSE;
+  }
+  return $rc;
+}
+
+/**
+ * Return a Memcache object for the specified bin.
+ *
+ * Note that there is nothing preventing developers from calling this function
+ * directly to get the Memcache object. Do this if you need functionality not
+ * provided by this API or if you need to use legacy code. Otherwise, use the
+ * dmemcache (get, set, delete, flush) API functions provided here.
+ *
+ * @param string $bin
+ *   The bin which is to be used.
+ * @param bool $reset
+ *   If TRUE will reset all static caches. Defaults to FALSE.
+ *   To force a reconnection to memcached, first call $mc->quit() or
+ *   $mc->close() (as appropriate for your PECL extension).
+ *
+ * @return mixed
+ *   A Memcache object, or FALSE on failure.
+ */
+function dmemcache_object($bin = NULL, $reset = FALSE) {
+  static $memcache_cache = array();
+  static $memcache_servers = array();
+  static $memcache_bins = array();
+  static $failed_connections = array();
+
+  if ($reset) {
+    $memcache_cache = array();
+    $memcache_servers = array();
+    $memcache_bins = array();
+    $failed_connections = array();
+  }
+
+  if (empty($memcache_cache) || empty($memcache_cache[$bin])) {
+    if (empty($memcache_servers)) {
+      // Load the variables from settings.php if set.
+      $memcache_servers = variable_get('memcache_servers', array('127.0.0.1:11211' => 'default'));
+      $memcache_bins = variable_get('memcache_bins', array('cache' => 'default'));
+    }
+
+    // If not manually set, default this cluster to 'default'.
+    $cluster = empty($memcache_bins[$bin]) ? 'default' : $memcache_bins[$bin];
+
+    // If not manually set, map this bin to 'cache' which maps to the 'default'
+    // cluster.
+    if (empty($memcache_bins[$bin]) && !empty($memcache_cache['cache'])) {
+      $memcache_cache[$bin] = &$memcache_cache['cache'];
+    }
+    else {
+      // Create a new memcache object for each cluster.
+      $memcache = dmemcache_instance($bin);
+
+      // Track whether or not we've opened any memcache connections.
+      $connection = FALSE;
+      // Link all the servers to this cluster.
+      foreach ($memcache_servers as $server => $b) {
+        if ($c = dmemcache_object_cluster($b)) {
+          if ($c['cluster'] == $cluster && !isset($failed_connections[$server])) {
+            $rc = dmemcache_connect($memcache, $server, $c['weight'], $connection);
+            if ($rc) {
+              // We've made at least one connection.
+              $connection = TRUE;
+            }
+            else {
+              // Memcache connection failure. We can't log to watchdog directly
+              // because we're in an early Drupal bootstrap phase where watchdog
+              // is non-functional. Instead, register a shutdown handler so it
+              // gets recorded at the end of the page load.
+              register_shutdown_function('watchdog', 'memcache', 'Failed to connect to memcache server: !server', array('!server' => $server), WATCHDOG_ERROR);
+              $failed_connections[$server] = FALSE;
+            }
+          }
+        }
+      }
+      if ($connection) {
+        // Map the current bin with the new Memcache object.
+        $memcache_cache[$bin] = $memcache;
+
+        // Now that all the servers have been mapped to this cluster, look for
+        // other bins that belong to the cluster and map them too.
+        foreach ($memcache_bins as $b => $c) {
+          if ($c == $cluster && $b != $bin) {
+            // Map this bin and cluster by reference.
+            $memcache_cache[$b] = &$memcache_cache[$bin];
+          }
+        }
+      }
+    }
+  }
+
+  return empty($memcache_cache[$bin]) ? FALSE : $memcache_cache[$bin];
+}
+
+/**
+ * Ensure that we're working with a proper cluster array.
+ */
+function dmemcache_object_cluster($cluster) {
+  if (!is_array($cluster)) {
+    // Set defaults.
+    $cluster = array(
+      'cluster' => $cluster,
+      'weight' => 1,
+    );
+  }
+  if (!isset($cluster['cluster']) || !is_string($cluster['cluster'])) {
+    // Cluster is required, complain if it's missing or invalid.
+    register_shutdown_function('watchdog', 'memcache', 'Ignoring invalid or missing cluster definition, review your memcache_servers configuration.', array(), WATCHDOG_ERROR);
+    return FALSE;
+  }
+  if (!isset($cluster['weight']) || !is_int($cluster['weight']) || $cluster['weight'] < 1) {
+    // Weight is optional.
+    $cluster['weight'] = 1;
+  }
+  return $cluster;
+}
+
+/**
+ * Prefixes a key and ensures it is url safe.
+ *
+ * @param string $key
+ *   The key to prefix and encode.
+ * @param string $bin
+ *   The cache bin which the key applies to.
+ * @param string $multiple
+ *   If TRUE will return all possible prefix variations.
+ *
+ * @return string or array
+ *   The prefixed and encoded key(s).
+ */
+function dmemcache_key($key, $bin = 'cache', $multiple = FALSE) {
+  $prefix = '';
+  if ($prefixes = variable_get('memcache_key_prefix', '')) {
+    if (is_array($prefixes)) {
+      // If no custom prefix defined for bin, use 'default'.
+      if (empty($prefixes[$bin])) {
+        $bin = 'default';
+      }
+      if (!empty($prefixes[$bin])) {
+        // There can be multiple prefixes specified for each bin.
+        if (is_array($prefixes[$bin])) {
+          // Optionally return key with all prefixes.
+          if ($multiple) {
+            $prefix = array();
+            foreach ($prefixes[$bin] as $pre) {
+              $prefix[] = $pre . '-';
+            }
+          }
+          // Otherwise just return a single prefixed key.
+          else {
+            $prefix = $prefixes[$bin][0] . '-';
+          }
+        }
+      }
+    }
+    else {
+      $prefix = $prefixes . '-';
+    }
+  }
+
+  if (!is_array($prefix)) {
+    $prefix = array($prefix);
+  }
+  $full_keys = array();
+  foreach ($prefix as $p) {
+    // When simpletest is running, emulate the simpletest database prefix here
+    // to avoid the child site setting cache entries in the parent site.
+    if (isset($GLOBALS['drupal_test_info']['test_run_id'])) {
+      $p .= $GLOBALS['drupal_test_info']['test_run_id'];
+    }
+    $full_keys[] = urlencode($p . $bin . '-' . $key);
+  }
+
+  // Memcache truncates keys longer than 250 characters[*]. This could lead to
+  // cache collisions, so we hash keys that are longer than this while still
+  // retaining as much of the key bin and name as possible to aid in debugging.
+  // The hashing algorithm used is configurable, with sha1 selected by default
+  // as it performs quickly with minimal collisions. You can enforce shorter
+  // keys by setting memcache_key_max_length in settings.php.
+  // [*]https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L47
+  $maxlen = variable_get('memcache_key_max_length', 250);
+
+  foreach ($full_keys as $k => $full_key) {
+    if (strlen($full_key) > $maxlen) {
+      $full_keys[$k] = urlencode($prefix[$k] . $bin) . '-' . hash(variable_get('memcache_key_hash_algorithm', 'sha1'), $key);
+      $full_keys[$k] .= '-' . substr(urlencode($key), 0, ($maxlen - 1) - strlen($full_keys[$k]) - 1);
+    }
+  }
+
+  if ($multiple) {
+    // An array of prefixed keys.
+    return $full_keys;
+  }
+  else {
+    // A single prefixed key.
+    return array_shift($full_keys);
+  }
+}
+
+/**
+ * Track active keys with multi-piece values, necessary for efficient cleanup.
+ *
+ * We can't use variable_get/set for tracking this information because if the
+ * variables array grows >1M and has to be split into pieces we'd get stuck in
+ * an infinite loop. Storing this information in memcache means it can be lost,
+ * but in that case the pieces will still eventually be auto-expired by
+ * memcache.
+ *
+ * @param string $cid
+ *   The cid of the root multi-piece value.
+ * @param integer $exp
+ *   Timestamp when the cached item expires. If NULL, the $cid will be deleted.
+ *
+ * @return bool
+ *   TRUE on succes, FALSE otherwise.
+ */
+function dmemcache_piece_cache_set($cid, $exp = NULL) {
+  // Always refresh cached copy to minimize multi-thread race window.
+  $piece_cache = &drupal_static('dmemcache_piece_cache', array());
+  $piece_cache = dmemcache_get('__dmemcache_piece_cache');
+  if (!is_array($piece_cache)) {
+    $piece_cache = array();
+  }
+
+  if (isset($exp)) {
+    if ($exp <= 0) {
+      // If no expiration time is set, defaults to 30 days.
+      $exp = REQUEST_TIME + 2592000;
+    }
+    $piece_cache[$cid] = $exp;
+  }
+  else {
+    unset($piece_cache[$cid]);
+  }
+
+  return dmemcache_set('__dmemcache_piece_cache', $piece_cache);
+}
+
+/**
+ * Determine if a key has multi-piece values.
+ *
+ *
+ * @param string $cid
+ *   The cid to check for multi-piece values.
+ *
+ * @return integer
+ *   Expiration time if key has multi-piece values, otherwise FALSE.
+ */
+function dmemcache_piece_cache_get($name) {
+  static $drupal_static_fast;
+  if (!isset($drupal_static_fast)) {
+    $drupal_static_fast['piece_cache'] = &drupal_static('dmemcache_piece_cache', FALSE);
+  }
+  $piece_cache = &$drupal_static_fast['piece_cache'];
+
+  if (!is_array($piece_cache)) {
+    $piece_cache = dmemcache_get('__dmemcache_piece_cache');
+    // On a website with no over-sized cache pieces, initialize the variable so
+    // we never load it more than once per page versus once per DELETE.
+    if (!is_array($piece_cache)) {
+      dmemcache_set('__dmemcache_piece_cache', array());
+    }
+  }
+
+  if (isset($piece_cache[$name])) {
+    // Return the expiration time of the multi-piece cache item.
+    return $piece_cache[$name];
+  }
+  // Item doesn't have multiple pieces.
+  return FALSE;
+}
+
+/**
+ * Collect statistics if enabled.
+ *
+ * Optimized function to determine whether or not we should be collecting
+ * statistics. Also starts a timer to track how long individual memcache
+ * operations take.
+ *
+ * @return bool
+ *   TRUE or FALSE if statistics should be collected.
+ */
+function dmemcache_stats_init() {
+  static $drupal_static_fast;
+
+  if (!isset($drupal_static_fast)) {
+    $drupal_static_fast = &drupal_static(__FUNCTION__, array('variable_checked' => NULL, 'user_access_checked' => NULL));
+  }
+  $variable_checked = &$drupal_static_fast['variable_checked'];
+  $user_access_checked  = &$drupal_static_fast['user_access_checked'];
+
+  // Confirm DRUPAL_BOOTSTRAP_VARIABLES has been reached. We don't use
+  // drupal_get_bootstrap_phase() as it's buggy. We can use variable_get() here
+  // because _drupal_bootstrap_variables() includes module.inc immediately
+  // after it calls variable_initialize().
+  if (!isset($variable_checked) && function_exists('module_list')) {
+    $variable_checked = variable_get('show_memcache_statistics', FALSE);
+  }
+  // If statistics are enabled we need to check user access.
+  if (!empty($variable_checked) && !isset($user_access_checked) && !empty($GLOBALS['user']) && function_exists('user_access')) {
+    // Statistics are enabled and the $user object has been populated, so check
+    // that the user has access to view them.
+    $user_access_checked = user_access('access memcache statistics');
+  }
+  // Return whether or not statistics are enabled and the user can access them.
+  if ((!isset($variable_checked) || $variable_checked) && (!isset($user_access_checked) || $user_access_checked)) {
+    timer_start('dmemcache');
+    return TRUE;
+  }
+  else {
+    return FALSE;
+  }
+}
+
+/**
+ * Save memcache statistics to be displayed at end of page generation.
+ *
+ * @param string $action
+ *   The action being performed (get, set, etc...).
+ * @param string $bin
+ *   The memcache bin the action is being performed in.
+ * @param array $keys
+ *   Keyed array in the form (string)$cid => (bool)$success. The keys the
+ *   action is being performed on, and whether or not it was a success.
+ */
+function dmemcache_stats_write($action, $bin, $keys) {
+  global $_dmemcache_stats;
+  // Determine how much time elapsed to execute this action.
+  $time = timer_read('dmemcache');
+  // Build the 'all' and 'ops' arrays displayed by memcache_admin.module.
+  foreach ($keys as $key => $success) {
+    $_dmemcache_stats['all'][] = array(
+      number_format($time, 2),
+      $action,
+      $bin,
+      $key,
+      $success ? 'hit' : 'miss',
+    );
+    if (!isset($_dmemcache_stats['ops'][$action])) {
+      $_dmemcache_stats['ops'][$action] = array($action, 0, 0, 0);
+    }
+    $_dmemcache_stats['ops'][$action][1] += $time;
+    if ($success) {
+      $_dmemcache_stats['ops'][$action][2]++;
+    }
+    else {
+      $_dmemcache_stats['ops'][$action][3]++;
+    }
+  }
+  // Reset the dmemcache timer for timing the next memcache operation.
+}
+
+/**
+ * Write to a debug log when enabled.
+ *
+ * @param string $action
+ *   The action being performed (get, set, etc...).
+ * @param string $bin
+ *   The memcache bin the action is being performed in.
+ * @param string $key
+ *   The key on which the action is being performed on.
+ * @param bool $rc
+ *   The return code of the action performed.
+ */
+function _dmemcache_write_debug($action, $bin, $key, $rc) {
+  static $memcache_debug_log = NULL;
+  static $memcache_debug_verbose = NULL;
+  if ($memcache_debug_log === NULL) {
+    $memcache_debug_log = variable_get('memcache_debug_log', FALSE);
+    $memcache_debug_verbose = variable_get('memcache_debug_verbose', FALSE);
+  }
+  if (($action == 'get' || $action == 'getMulti') && !$memcache_debug_verbose) {
+    return;
+  }
+  elseif ($memcache_debug_log) {
+    $debug_log = strtr(variable_get('memcache_debug_log_format', "!timestamp|!action|!bin|!cid|!rc\n"), array('!timestamp' => date(variable_get('memcache_debug_time_format', 'U')), '!action' => $action, '!bin' => $bin, '!cid' => $key, '!rc' => (int) $rc));
+    if (file_put_contents($memcache_debug_log, $debug_log, FILE_APPEND) === FALSE) {
+      // This can lead to a lot of watchdog entries...
+      register_shutdown_function('watchdog', 'memcache', 'Unable to write to debug log at !debug_file: !debug_log.', array('!debug_file' => $memcache_debug_log, '!debug_log' => $debug_log), WATCHDOG_ERROR);
+    }
+  }
+}
+
+/**
+ * Ensures memcache connection is authorized for the server
+ * that is mapped for the given key.
+ *
+ * @param string $full_key
+ *   The full key for the item whose server is checked for ascii
+ *   authentication.
+ * @param object $mc
+ *   The memcache object.
+ *
+ * @return bool
+ *   TRUE if the connection is authorized, FALSE otherwise.
+ */
+function _dmemcache_ensure_ascii_auth($full_key, $mc) {
+  static $memcache_ascii_auth = NULL;
+  static $memcache_ascii_auth_token = NULL;
+
+  if (!isset($memcache_ascii_auth)) {
+    $memcache_ascii_auth = _dmemcache_use_ascii_auth();
+    $memcache_ascii_auth_token = variable_get('memcache_ascii_auth', FALSE);
+  }
+
+  // Immediately return if there is no memcache authentication.
+  if (!$memcache_ascii_auth) {
+    return FALSE;
+  }
+
+  // Login to the server.
+  $rc = $mc->setByKey($full_key, DRUPAL_MEMCACHE_ASCII_AUTH_KEY, $memcache_ascii_auth_token);
+  if (!$rc && $mc->getResultCode() == MEMCACHED_SERVER_TIMED_OUT) {
+    // Quitting is the only way to recover from this failure.
+    $mc->quit();
+    $rc = $mc->setByKey($full_key, DRUPAL_MEMCACHE_ASCII_AUTH_KEY, $memcache_ascii_auth_token);
+  }
+  if (!$rc) {
+    $code = $mc->getResultCode();
+    $message = $mc->getResultMessage();
+    $t = explode(' ', $memcache_ascii_auth_token);
+    $s = $mc->getServerByKey($full_key);
+
+    register_shutdown_function('watchdog', 'memcache', 'Memcache ascii authentication failed to login with user %user to server: %server; error code: %code with message %message', array(
+      '%server' => $s['host'] . ':' . $s['port'],
+      '%user' => $t[0],
+      '%code' => $code,
+      '%message' => $message,
+    ), WATCHDOG_ERROR);
+
+    return FALSE;
+  }
+
+  // Login was successful, check if our lifetime key exists already.
+  $rc = $mc->getByKey($full_key, DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY);
+  if ($rc) {
+    return TRUE;
+  }
+
+  // Set the lifetime key.
+  $mc->setByKey($full_key, DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY, TRUE);
+
+  // Confirm the lifetime key properly set, setByKey() can return success
+  // even when it fails.
+  return $mc->getByKey($full_key, DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY);
+}
+
+/**
+ * Performs ascii authentication to the server given by host and port.
+ *
+ * @param string $host
+ *   The hostname of the server to authenticate to.
+ * @param int $port
+ *   The port of the server to authenticate to.
+ * @param object $mc
+ *   The memcache object.
+ *
+ * @return bool
+ *   TRUE on success, FALSE otherwise.
+ */
+function _dmemcache_ascii_authenticate_server($host, $port, $mc) {
+  $rc = FALSE;
+
+  // Find a working key that matches the specified server.
+  for ($key = 0; $key < 1000; $key++) {
+    // It's impossible to directly address a server, but we need to
+    // login to the specified connection before it can be used.
+    // So we check all keys from 0 to 1000 if it would map to this server.
+    // Once we have found one, we set the authentication data, because any key
+    // will work for authentication as the authentication data includes user and
+    // password.
+    $s = $mc->getServerByKey($key);
+    if ($s['host'] == $host && $s['port'] == $port) {
+      $rc = _dmemcache_ensure_ascii_auth($key, $mc);
+      break;
+    }
+  }
+
+  // This should never happen.
+  if ($key == 1000) {
+    register_shutdown_function('watchdog', 'memcache', 'Memcache ascii authentication could not find the server to authenticate to.', array(), WATCHDOG_ERROR);
+    return FALSE;
+  }
+
+  return $rc;
+}
+
+/**
+ * Checks if cache items are really missing or only missing ascii authentication.
+ *
+ * This is essentially a cache miss and hence we would be going into a heavy
+ * code path anyway, therefore it is performance wise okay to check a special
+ * key that exists on all memcache servers to see if this is:
+ *
+ * a) real cache miss (where we need to do all the hard work)
+ * b) ascii authentication failure (where we just need to login and then can
+ *    hopefully have a cache hit)
+ *
+ * The edge case of the special lifetime key not existing is treated as a real
+ * cache miss.
+ *
+ * This is justified by the case that most likely memcache was just restarted
+ * (else the lifetime key would not be missing) and hence the real cache request
+ * likely would have been a real cache miss anyway.
+ *
+ * @param array $results
+ *   The results array to check for a 2nd chance.
+ * @param object $mc
+ *   The memcache object.
+ */
+function _dmemcache_get_multi_2nd_chance_ascii_auth($results, $mc) {
+  // Cache misses are very costly: Find out, if any servers need authentication.
+  $servers = array();
+  foreach ($results as $full_key => $value) {
+    if (!empty($value)) {
+      continue;
+    }
+
+    $s = $mc->getServerByKey($full_key);
+    $server_key = $s['host'] . ':' . $s['port'];
+    $servers[$server_key][$full_key] = $full_key;
+  }
+
+  if (empty($servers)) {
+    return array();
+  }
+
+  $try_again_full_keys = array();
+  foreach ($servers as $server_key => $full_keys) {
+    // Use the first key of the list as all keys map to this server.
+    $full_key = current($full_keys);
+
+    // Check if lifetime token exists and hence if we are authorized
+    // on this server.
+    $rc = $mc->getByKey($full_key, DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY);
+    if (empty($rc) && _dmemcache_ensure_ascii_auth($full_key, $mc)) {
+      // If we logged in after first failing a fetch for our lifetime key,
+      // then these keys need to be retried as the "not found" could have been
+      // an authentication failure.
+      $try_again_full_keys += $full_keys;
+    }
+  }
+
+  // In case no authentication succeeded, there will be no keys to get.
+  if (empty($try_again_full_keys)) {
+    return array();
+  }
+
+  $new_results = $mc->getMulti($try_again_full_keys);
+  if (empty($new_results)) {
+    return array();
+  }
+
+  return $new_results;
+}
+
+/**
+ * If using ascii authentication, re-authenticates all servers.
+ *
+ * @param string $mc
+ *   The mc object to re-authenticate all servers on.
+ *
+ * @return bool
+ *   TRUE on success, FALSE on failure.
+ */
+function _dmemcache_reset_ascii_auth($mc) {
+  static $memcache_ascii_auth = NULL;
+
+  if (!isset($memcache_ascii_auth)) {
+    $memcache_ascii_auth = _dmemcache_use_ascii_auth();
+  }
+
+  if (!$memcache_ascii_auth) {
+    return FALSE;
+  }
+
+  // Need to check all servers for authentication.
+  $servers = $mc->getServerList();
+  foreach ($servers as $s) {
+    $rc = _dmemcache_ascii_authenticate_server($s['host'], $s['port'], $mc);
+    if (!$rc) {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+ * Returns whether memcache_ascii_auth is used or not.
+ *
+ * @return bool
+ *   TRUE if authentication is used, FALSE otherwise.
+ */
+function _dmemcache_use_ascii_auth() {
+  static $memcache_ascii_auth = NULL;
+
+  if (!isset($memcache_ascii_auth)) {
+    $memcache_ascii_auth = variable_get('memcache_ascii_auth', FALSE);
+    $extension = dmemcache_extension();
+
+    if ($memcache_ascii_auth && $extension == 'Memcache') {
+      register_shutdown_function('watchdog', 'memcache', 'Memcache ascii authentication can only be used with Memcached extension', array(), WATCHDOG_ERROR);
+      $memcache_ascii_auth = FALSE;
+    }
+  }
+
+  return (bool) $memcache_ascii_auth;
+}

--- a/html/sites/all/modules/contrib/memcache/memcache-lock-code.inc
+++ b/html/sites/all/modules/contrib/memcache/memcache-lock-code.inc
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * @file
+ * A memcache based implementation of a locking mechanism.
+ * See includes/lock.inc for documenation
+ *
+ * ATTENTION: Don't include this file directly - use the memcache-lock.inc to
+ * have a failover solution.
+ */
+
+/**
+ * Initialize the locking system.
+ */
+function lock_initialize() {
+  global $locks;
+
+  $locks = array();
+}
+
+/**
+ * Acquire (or renew) a lock, but do not block if it fails.
+ *
+ * @param string $name
+ *   The name of the lock.
+ * @param int $timeout
+ *   A number of seconds (int) before the lock expires (minimum of 1).
+ *
+ * @return bool
+ *   TRUE if the lock was acquired, FALSE if it failed.
+ */
+function lock_acquire($name, $timeout = 30) {
+  global $locks;
+
+  // Special case variable_init, as on memcache errors we can get stuck in an
+  // infinite loop.
+  static $variable_init = 0;
+  if ($name == 'variable_init') {
+    if ($variable_init > 25) {
+      register_shutdown_function('watchdog', 'memcache', 'Broke out of loop trying to grab lock for variable_init.');
+      return TRUE;
+    }
+    $variable_init++;
+  }
+
+  // Ensure that the timeout is at least 1 sec. This is a limitation
+  // imposed by memcached.
+  $timeout = (int) max($timeout, 1);
+
+  if (dmemcache_add($name, _lock_id(), $timeout, 'semaphore')) {
+    $locks[$name] = _lock_id();
+  }
+  elseif (($result = dmemcache_get($name, 'semaphore')) && isset($locks[$name]) && $locks[$name] == $result) {
+    // Only renew the lock if we already set it and it has not expired.
+    dmemcache_set($name, _lock_id(), $timeout, 'semaphore');
+  }
+  else {
+    // Failed to acquire the lock.  Unset the key from the $locks array even if
+    // not set, PHP 5+ allows this without error or warning.
+    unset($locks[$name]);
+  }
+
+  return isset($locks[$name]);
+}
+
+/**
+ * Check if lock acquired by a different process may be available.
+ *
+ * If an existing lock has expired, it is removed.
+ *
+ * @param string $name
+ *   The name of the lock.
+ *
+ * @return bool
+ *   TRUE if there is no lock or it was removed, FALSE otherwise.
+ */
+function lock_may_be_available($name) {
+  return !dmemcache_get($name, 'semaphore');
+}
+
+/**
+ * Wait for a lock to be available.
+ *
+ * This function may be called in a request that fails to acquire a desired
+ * lock. This will block further execution until the lock is available or the
+ * specified delay in seconds is reached. This should not be used with locks
+ * that are acquired very frequently, since the lock is likely to be acquired
+ * again by a different request while waiting.
+ *
+ * @param string $name
+ *   The name of the lock.
+ * @param int $delay
+ *   The maximum number of seconds to wait, as an integer.
+ *
+ * @return bool
+ *   TRUE if the lock holds, FALSE if it is available.
+ */
+function lock_wait($name, $delay = 30) {
+  /*
+   * Pause the process for short periods between calling
+   * lock_may_be_available(). This prevents hitting the database with constant
+   * database queries while waiting, which could lead to performance issues.
+   * However, if the wait period is too long, there is the potential for a
+   * large number of processes to be blocked waiting for a lock, especially
+   * if the item being rebuilt is commonly requested. To address both of these
+   * concerns, begin waiting for 25ms, then add 25ms to the wait period each
+   * time until it reaches 500ms. After this point polling will continue every
+   * 500ms until $delay is reached.
+   */
+
+  // $delay is passed in seconds, but we will be using usleep(), which takes
+  // microseconds as a parameter. Multiply it by 1 million so that all
+  // further numbers are equivalent.
+  $delay = (int) $delay * 1000000;
+
+  // Begin sleeping at 25ms.
+  $sleep = 25000;
+  while ($delay > 0) {
+    // This function should only be called by a request that failed to get a
+    // lock, so we sleep first to give the parallel request a chance to finish
+    // and release the lock.
+    usleep($sleep);
+    // After each sleep, increase the value of $sleep until it reaches
+    // 500ms, to reduce the potential for a lock stampede.
+    $delay = $delay - $sleep;
+    $sleep = min(500000, $sleep + 25000, $delay);
+    if (!dmemcache_get($name, 'semaphore')) {
+      // No longer need to wait.
+      return FALSE;
+    }
+  }
+  // The caller must still wait longer to get the lock.
+  return TRUE;
+}
+
+/**
+ * Release a lock previously acquired by lock_acquire().
+ *
+ * This will release the named lock if it is still held by the current request.
+ *
+ * @param string $name
+ *   The name of the lock.
+ */
+function lock_release($name) {
+  global $locks;
+
+  if (isset($locks[$name]) && (dmemcache_get($name, 'semaphore') == $locks[$name])) {
+    dmemcache_delete($name, 'semaphore');
+    // We unset unconditionally since caller assumes lock is released anyway.
+    unset($locks[$name]);
+  }
+}
+
+/**
+ * Generate a unique identifier for locks generated during this request.
+ */
+function _lock_id() {
+  static $lock_id;
+  if (!isset($lock_id)) {
+    $lock_id = uniqid(mt_rand(), TRUE);
+    // We only register a shutdown function if a lock is used.
+    register_shutdown_function('lock_release_all', $lock_id);
+  }
+  return $lock_id;
+}
+
+/**
+ * Release all locks acquired by this request.
+ */
+function lock_release_all($lock_id = NULL) {
+  global $locks;
+  foreach ($locks as $name => $id) {
+    $value = dmemcache_get($name, 'semaphore');
+
+    if ($value == $id) {
+      dmemcache_delete($name, 'semaphore');
+    }
+  }
+}

--- a/html/sites/all/modules/contrib/memcache/memcache-lock.inc
+++ b/html/sites/all/modules/contrib/memcache/memcache-lock.inc
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * A memcache based implementation of a locking mechanism.
+ * See includes/lock.inc for documenation
+ */
+
+require_once dirname(__FILE__) . '/dmemcache.inc';
+
+// Check if memcached is available - if not include default lock handler.
+// @todo get rid of this conditional include as soon as this is done:
+// http://drupal.org/node/1225404
+$lock_file = dirname(__FILE__) . '/memcache-lock-code.inc';
+$mc = dmemcache_object('semaphore');
+// dmemcache_object may return FALSE, we don't need these stats but it forces
+// us to try and connect to memcache. If this fails, we can't store locks in
+// memcache.
+$connection_okay = $mc && !empty($mc->getStats());
+
+// Reset the server list and try the getStats() call again.
+if (!$connection_okay && $mc && _dmemcache_reset_ascii_auth($mc)) {
+  $connection_okay = !empty($mc->getStats());
+}
+
+if (!$connection_okay) {
+  $lock_file = DRUPAL_ROOT . '/includes/lock.inc';
+}
+require_once $lock_file;

--- a/html/sites/all/modules/contrib/memcache/memcache.drush.inc
+++ b/html/sites/all/modules/contrib/memcache/memcache.drush.inc
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @file
+ * Provides a drush interface to Memcached.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function memcache_drush_command() {
+  $items['memcache-stats'] = array(
+    'description' => dt('Retrieve statistics from memcache.'),
+    'arguments' => array(
+      'bin' => dt('Optionally specify which bin; defaults to \'cache\'.'),
+      'type' => dt('Optionally specify type of statistics; one of {default, reset, malloc, slabs, cachedump, items, sizes}.'),
+    ),
+    'options' => array(
+      'interactive' => dt('Interactivly specify which type of statistics to display.'),
+      'aggregate' => dt('Included combined statistics from all servers.'),
+    ),
+    'required-arguments' => 0,
+    'examples' => array(
+      'memcache-stats' => 'Display raw statistics.',
+      'memcache-stats --aggregate' => 'Display raw statistics for all servers and combined totals',
+      'memcache-stats --interactive' => 'Interactively select which type of statistics to display.',
+      'memcache-stats cache slabs' => 'Display slabs allocated for cache bin.',
+    ),
+    'aliases' => array('mcs'),
+  );
+
+  $items['memcache-flush'] = array(
+    'description' => dt('Flush all objects from a bin.'),
+    'arguments' => array(
+      'bin' => dt('Optionally specify which bin to flush; defaults to \'cache\'.'),
+    ),
+    'required-arguments' => 0,
+    'examples' => array(
+      'memcache-clear' => 'Flush all items in \'cache\' bin.',
+      'memcache-clear cache-page' => 'Flush all items in \'cache-page\' bin.',
+    ),
+    'aliases' => array('mcf'),
+  );
+
+  return $items;
+}
+
+/**
+ * Display memcache statistics.
+ *
+ * @param string $bin
+ *   The bin to retrieve statistics for.
+ * @param string $stats_type
+ *   The type of statistics to retrieve when using the Memcache extension.
+ */
+function drush_memcache_stats($bin = 'cache', $stats_type = 'default') {
+  if (_memcache_is_available()) {
+    $interactive = drush_get_option('interactive', 0);
+    $aggregate = drush_get_option('aggregate', 0);
+    if ($interactive) {
+      $options = array(
+        'default' => 'default',
+        'reset' => 'reset',
+        'malloc' => 'malloc',
+        'slabs' => 'slabs',
+        'cachedump' => 'cachedump',
+        'items' => 'items',
+        'sizes' => 'sizes',
+      );
+      $stats_type = drush_choice($options, dt('What type of statistics would you like to see?'));
+      // stats_type of FALSE === Cancel
+      if ($stats_type === FALSE) {
+        return;
+      }
+    }
+    $stats = dmemcache_stats($bin, $stats_type, $aggregate);
+
+    drush_print_r($stats);
+  }
+}
+
+/**
+ * Invalidate all items in specified bin.
+ *
+ * @param string $bin
+ *   The bin to flush. Note that this will flush all bins mapped to the same
+ *   server as $bin. There is no way at this time to empty just one bin.
+ *
+ * @return bool
+ *   Returns TRUE on success or FALSE on failure.
+ */
+function drush_memcache_flush($bin = 'cache') {
+  if (_memcache_is_available()) {
+    $flushed = dmemcache_flush($bin);
+
+    if ($flushed === TRUE) {
+      drush_log(dt('Successfully cleared !bin bin.', array('!bin' => $bin)), 'ok');
+    }
+    else {
+      drush_log(dt('Failed to clear !bin bin.', array('!bin' => $bin)), 'error');
+    }
+  }
+}
+
+/**
+ * Implements drush_hook_COMMAND_validate().
+ */
+function drush_memcache_flush_validate() {
+  return _memcache_is_available();
+}
+
+/**
+ * Implements drush_hook_COMMAND_validate().
+ */
+function drush_memcached_stats_validate() {
+  return _memcache_is_available();
+}
+
+/**
+ * Check if memcache.inc has been included.
+ */
+function _memcache_is_available() {
+  if (!class_exists('MemCacheDrupal', FALSE)) {
+    return drush_set_error("MemCacheDrupal class is not available", "Please review README.txt and properly enable memcache.");;
+  }
+  return TRUE;
+}

--- a/html/sites/all/modules/contrib/memcache/memcache.inc
+++ b/html/sites/all/modules/contrib/memcache/memcache.inc
@@ -1,0 +1,681 @@
+<?php
+
+/**
+ * @file
+ * Implementation of cache.inc with memcache logic included.
+ */
+
+require_once dirname(__FILE__) . '/dmemcache.inc';
+
+/**
+ * Defines the period after which wildcard clears are not considered valid.
+ */
+define('MEMCACHE_WILDCARD_INVALIDATE', 86400 * 28);
+define('MEMCACHE_CONTENT_CLEAR', 'MEMCACHE_CONTENT_CLEAR');
+
+/**
+ * Implementation of cache.inc with memcache logic included
+ */
+class MemCacheDrupal implements DrupalCacheInterface {
+  protected $memcache;
+
+  /**
+   * Constructs a MemCacheDrupal object.
+   *
+   * @param string $bin
+   *   The cache bin for which the object is created.
+   */
+  public function __construct($bin) {
+    $this->memcache = dmemcache_object($bin);
+    $this->bin = $bin;
+
+    // If page_cache_without_database is enabled, we have to manually load the
+    // $conf array out of cache_bootstrap.
+    static $variables_loaded = FALSE;
+    // NOTE: We don't call drupal_get_bootstrap_phase() because this would
+    // break all 7.x Drupal installations prior to 7.33. For more information
+    // see https://www.drupal.org/node/667098.
+    if (drupal_bootstrap(NULL, FALSE) < DRUPAL_BOOTSTRAP_VARIABLES && !$variables_loaded) {
+      global $conf;
+      $variables_loaded = TRUE;
+      // Try loading variables from cache. If that fails, we have to bootstrap
+      // further in order to fetch them.
+      if ($cached = cache_get('variables', 'cache_bootstrap')) {
+        $variables = $cached->data;
+        // Make sure variable overrides are applied, see variable_initialize().
+        foreach ($conf as $name => $value) {
+          $variables[$name] = $value;
+        }
+        $conf = $variables;
+      }
+      else {
+        drupal_bootstrap(DRUPAL_BOOTSTRAP_VARIABLES, FALSE);
+      }
+    }
+
+    $this->reloadVariables();
+  }
+
+  /**
+   * Implements DrupalCacheInterface::get().
+   */
+  public function get($cid) {
+    // Clean up.
+    $this->garbageCollection();
+    $cache = dmemcache_get($cid, $this->bin, $this->memcache);
+    return $this->valid($cid, $cache) ? $cache : FALSE;
+  }
+
+  /**
+   * Implements DrupalCacheInterface::getMultiple().
+   */
+  public function getMultiple(&$cids) {
+    // Clean up.
+    $this->garbageCollection();
+    $results = dmemcache_get_multi($cids, $this->bin, $this->memcache);
+    foreach ($results as $cid => &$result) {
+      if (!$this->valid($cid, $result)) {
+        // This object has expired, so don't return it.
+        unset($results[$cid]);
+      }
+    }
+    // Remove items from the referenced $cids array that we are returning,
+    // per the comment in cache_get_multiple() in includes/cache.inc.
+    $cids = array_diff($cids, array_keys($results));
+    return $results;
+  }
+
+  /**
+   * Garbage collection for get() and getMultiple().
+   *
+   * This functions check for session indicators to NOT use the cache. It
+   * checks if the last cache clearing time in there expired and if so unsets
+   * them, so anonymous users can get out of the "sessions" after some time, to
+   * get fast delivered pages (e.g. from Varnish etc. again).
+   */
+  protected function garbageCollection() {
+    // Clean-up the per-user cache expiration session data, so that the session
+    // handler can properly clean-up the session data for anonymous users.
+    if (isset($_SESSION['cache_flush'])) {
+      foreach ($_SESSION['cache_flush'] as $bin => $timestamp) {
+        $expire = REQUEST_TIME - variable_get('cache_lifetime_' . $this->bin, variable_get('cache_lifetime', 0));
+        if ($timestamp < $expire) {
+          unset($_SESSION['cache_flush'][$bin]);
+        }
+      }
+      if (!$_SESSION['cache_flush']) {
+        unset($_SESSION['cache_flush']);
+      }
+    }
+  }
+
+  /**
+   * Checks if a retrieved cache item is valid.
+   *
+   * @param string $cid
+   *   The cache id of the item
+   * @param mixed $cache
+   *   The cache item, which will be updated if needed.
+   *
+   * @return bool
+   *   Whether the item is valid.
+   */
+  protected function valid($cid, &$cache) {
+    if ($cache) {
+      // Legacy support
+      if (!isset($cache->expire)) {
+        $cache->expire = CACHE_TEMPORARY;
+      }
+      if (!isset($cache->created)) {
+        $cache->created = 0;
+      }
+
+      // Session storage is used to simulate a cache clear for the current user
+      // when cache_lifetime is greater than 0.
+      $cache_tables = isset($_SESSION['cache_flush']) ? $_SESSION['cache_flush'] : NULL;
+
+      // Items that have expired are invalid. This includes CACHE_TEMPORARY
+      // items that were set prior to the last garbage collection, and
+      // timestamp set items.
+      //
+      // Test whether this cache has been garbage collected (general cache
+      // flush) longer ago than the cache_lifetime setting.
+      $cache_garbage_collected = $cache->created + $this->cache_lifetime <= $this->cache_temporary_flush;
+
+      // Depending on value of memcache_expire_wait_gc, test if a timestamp
+      // cached item has expired:
+      // If memcache_expired_wait_gc is true, this includes any timestamp items
+      // that expired more than cache_lifetime seconds before the last garbage
+      // collection. If memcache_expire_wait_gc is false, this includes any
+      // items that expired before present time.
+      $cache_timestamp_expired = variable_get('memcache_expire_wait_gc', FALSE) ? ($cache->expire + $this->cache_lifetime <= $this->cache_temporary_flush) : ($cache->expire <= REQUEST_TIME);
+
+      // Test for expired items.
+      if (($cache->expire == CACHE_TEMPORARY && $cache_garbage_collected) || ($cache->expire > 0 && $cache_timestamp_expired)) {
+        // If the memcache_stampede_protection variable is set, allow one
+        // process to rebuild the cache entry while serving expired content to
+        // the rest. Note that core happily returns expired cache items as valid
+        // and relies on cron to expire them, but this is mostly reliant on its
+        // use of CACHE_TEMPORARY which does not map well to memcache.
+        // @see http://drupal.org/node/534092
+        if (variable_get('memcache_stampede_protection', FALSE)) {
+          // The process that acquires the lock will get a cache miss, all
+          // others will get a cache hit.
+          if ($this->lockInit() && $this->stampedeProtected($cid) && lock_acquire("memcache_$cid:$this->bin", variable_get('memcache_stampede_semaphore', 15))) {
+            $cache = FALSE;
+          }
+        }
+        else {
+          $cache = FALSE;
+        }
+      }
+      // Items created before the last full wildcard flush against this bin are
+      // invalid.
+      elseif ($cache->created <= $this->cache_flush) {
+        $cache = FALSE;
+      }
+      // Items created before the last content flush on this bin i.e.
+      // cache_clear_all() are invalid.
+      elseif ($cache->expire != CACHE_PERMANENT && $cache->created + $this->cache_lifetime <= $this->cache_content_flush) {
+        $cache = FALSE;
+      }
+      // Items cached before the cache was last flushed by the current user are
+      // invalid.
+      elseif ($cache->expire != CACHE_PERMANENT && is_array($cache_tables) && isset($cache_tables[$this->bin]) && $cache_tables[$this->bin] >= $cache->created) {
+        // Cache item expired, return FALSE.
+        $cache = FALSE;
+      }
+      // Finally, check for wildcard clears against this cid.
+      else {
+        if (!$this->wildcardValid($cid, $cache)) {
+          $cache = FALSE;
+        }
+      }
+    }
+
+    // On cache misses, attempt to avoid stampedes when the
+    // memcache_stampede_protection variable is enabled.
+    if (!$cache) {
+      if (variable_get('memcache_stampede_protection', FALSE) && $this->lockInit() && $this->stampedeProtected($cid) && !lock_acquire("memcache_$cid:$this->bin", variable_get('memcache_stampede_semaphore', 15))) {
+        // Prevent any single request from waiting more than three times due to
+        // stampede protection. By default this is a maximum total wait of 15
+        // seconds. This accounts for two possibilities - a cache and lock miss
+        // more than once for the same item. Or a cache and lock miss for
+        // different items during the same request.
+        // @todo: it would be better to base this on time waited rather than
+        // number of waits, but the lock API does not currently provide this
+        // information. Currently the limit will kick in for three waits of 25ms
+        // or three waits of 5000ms.
+        static $lock_count = 0;
+        $lock_count++;
+        if ($lock_count <= variable_get('memcache_stampede_wait_limit', 3)) {
+          // The memcache_stampede_semaphore variable was used in previous
+          // releases of memcache, but the max_wait variable was not, so by
+          // default divide the semaphore value by 3 (5 seconds).
+          lock_wait("memcache_$cid:$this->bin", variable_get('memcache_stampede_wait_time', 5));
+          $cache = $this->get($cid);
+        }
+      }
+    }
+
+    $valid = (bool) $cache;
+
+    if (variable_get('memcache_pagecache_header', FALSE) && ($this->bin == 'cache_page')) {
+      // Per RFC-6648, don't start with X-
+      $header = t('Drupal-Pagecache-Memcache: !status', array('!status' => $valid ? t('HIT') : t('MISS')));
+      if ($valid) {
+        $header .= t(', age=!age', array('!age' => REQUEST_TIME - $cache->created));
+      }
+      header ($header);
+    }
+
+    return $valid;
+  }
+
+  /**
+   * Implements DrupalCacheInterface::set().
+   */
+  public function set($cid, $data, $expire = CACHE_PERMANENT) {
+    $created_microtime = round(microtime(TRUE), 3);
+
+    // Positive expiration values of less than 30 days are seconds. Convert to
+    // an absolute timestamp.
+    if ($expire > 0 && $expire < 2592000) {
+      $expire = REQUEST_TIME + $expire;
+    }
+
+    // Create new cache object.
+    $cache = new stdClass();
+    $cache->cid = $cid;
+    $cache->data = is_object($data) ? clone $data : $data;
+    $cache->created = REQUEST_TIME;
+    $cache->created_microtime = $created_microtime;
+    $cache->expire = $expire;
+    // Record the previous number of wildcard flushes affecting our cid.
+    $cache->flushes = $this->wildcardFlushes($cid);
+
+    // Determine stored memcache item lifetime.
+    if ($expire == CACHE_PERMANENT) {
+      // Set memcache item to never expire.
+      $memcache_expire = 0;
+    }
+    elseif (variable_get('memcache_expire_wait_gc', FALSE) || $expire == CACHE_TEMPORARY) {
+      // The cache_set() API states that an item set with a timestamp, once
+      // expired, behaves the same as CACHE_TEMPORARY: not removed till next
+      // general cache wipe (which is actually a garbage collection on each
+      // cache bin). However, the memcache module has traditionally treated
+      // timestamp-set items as expiring at that exact time. If
+      // memcache_expire_wait_gc is enabled, treat timestamp items the same as
+      // CACHE_TEMPORARY, and set the memcache expiration to something that
+      // keeps the item valid until the next garbage collection (30 days).
+      $memcache_expire = REQUEST_TIME + 2591999;
+    }
+    elseif (variable_get('memcache_stampede_protection', FALSE)) {
+      // If stampede protection is enabled, set the item expiration to twice
+      // its intended lifetime. The expired object may be served while one
+      // process rebuilds it.
+      $memcache_expire = REQUEST_TIME + (($expire - REQUEST_TIME) * 2);
+    }
+    else {
+      // Allow the memcache item to expire at the exact absolute timestamp.
+      $memcache_expire = $expire;
+    }
+    dmemcache_set($cid, $cache, $memcache_expire, $this->bin, $this->memcache);
+
+    // Release lock if acquired in $this->valid().
+    $lock = "memcache_$cid:$this->bin";
+    if (variable_get('memcache_stampede_protection', FALSE) && isset($GLOBALS['locks'][$lock])) {
+      lock_release("$lock");
+    }
+  }
+
+  /**
+   * Implements DrupalCacheInterface::clear().
+   */
+  public function clear($cid = NULL, $wildcard = FALSE) {
+    if ($this->memcache === FALSE) {
+      // No memcache connection.
+      return;
+    }
+
+    // It is not possible to detect a cache_clear_all() call other than looking
+    // at the backtrace unless http://drupal.org/node/81461 is added.
+    $backtrace = debug_backtrace();
+    if ($cid == MEMCACHE_CONTENT_CLEAR || (isset($backtrace[2]) && $backtrace[2]['function'] == 'cache_clear_all' && empty($backtrace[2]['args']))) {
+      // Update the timestamp of the last global flushing of this bin.  When
+      // retrieving data from this bin, we will compare the cache creation
+      // time minus the cache_flush time to the cache_lifetime to determine
+      // whether or not the cached item is still valid.
+      $this->cache_content_flush = time();
+      $this->variable_set('cache_content_flush_' . $this->bin, $this->cache_content_flush);
+      if (variable_get('cache_lifetime_' . $this->bin, variable_get('cache_lifetime', 0))) {
+        // We store the time in the current user's session. We then simulate
+        // that the cache was flushed for this user by not returning cached
+        // data to this user that was cached before the timestamp.
+        if (isset($_SESSION['cache_flush']) && is_array($_SESSION['cache_flush'])) {
+          $cache_bins = $_SESSION['cache_flush'];
+        }
+        else {
+          $cache_bins = array();
+        }
+        // Use time() rather than request time here for correctness.
+        $cache_tables[$this->bin] = $this->cache_content_flush;
+        $_SESSION['cache_flush'] = $cache_tables;
+      }
+    }
+    if (empty($cid) || $wildcard === TRUE) {
+      // system_cron() flushes all cache bins returned by hook_flush_caches()
+      // with cache_clear_all(NULL, $bin); The expected behaviour in this case
+      // is to perform garbage collection on expired cache items (which is
+      // irrelevant to memcache) but also to remove all CACHE_TEMPORARY items.
+      // @see https://api.drupal.org/api/drupal/includes!cache.inc/function/cache_clear_all/7
+      if (!isset($cid)) {
+        // Update the timestamp of the last CACHE_TEMPORARY clear. All
+        // temporary cache items created before this will be invalidated.
+        $this->cache_temporary_flush = time();
+        $this->variable_set("cache_temporary_flush_$this->bin", $this->cache_temporary_flush);
+        // Return early here as we do not want to register a wildcard flush.
+        return;
+      }
+      elseif ($cid == '*') {
+        $cid = '';
+      }
+      if (empty($cid)) {
+        // Update the timestamp of the last global flushing of this bin.  When
+        // retrieving data from this bin, we will compare the cache creation
+        // time minus the cache_flush time to the cache_lifetime to determine
+        // whether or not the cached item is still valid.
+        $this->cache_flush = time();
+        $this->variable_set("cache_flush_$this->bin", $this->cache_flush);
+        $this->flushed = min($this->cache_flush, time() - $this->cache_lifetime);
+
+        if ($this->cache_lifetime) {
+          // We store the time in the current user's session which is saved into
+          // the sessions table by sess_write().  We then simulate that the
+          // cache was flushed for this user by not returning cached data to
+          // this user that was cached before the timestamp.
+          if (isset($_SESSION['cache_flush']) && is_array($_SESSION['cache_flush'])) {
+            $cache_bins = $_SESSION['cache_flush'];
+          }
+          else {
+            $cache_bins = array();
+          }
+          $cache_bins[$this->bin] = $this->cache_flush;
+          $_SESSION['cache_flush'] = $cache_bins;
+        }
+      }
+      else {
+        // Register a wildcard flush for current cid.
+        $this->wildcards($cid, TRUE);
+      }
+    }
+    else {
+      $cids = is_array($cid) ? $cid : array($cid);
+      foreach ($cids as $cid) {
+        dmemcache_delete($cid, $this->bin, $this->memcache);
+      }
+    }
+  }
+
+  /**
+   * Sum of all matching wildcards.
+   *
+   * Checking any single cache item's flush value against this single-value sum
+   * tells us whether or not a new wildcard flush has affected the cached item.
+   *
+   * @param string $cid
+   *   The cache id to check.
+   *
+   * @return int
+   *   Sum of all matching wildcards for the given cache id.
+   */
+  protected function wildcardFlushes($cid) {
+    return array_sum($this->wildcards($cid));
+  }
+
+  /**
+   * Retrieves all matching wildcards for the given cache id.
+   *
+   * Utilize multiget to retrieve all possible wildcard matches, storing
+   * statically so multiple cache requests for the same item on the same page
+   * load doesn't add overhead.
+   */
+  protected function wildcards($cid, $flush = FALSE) {
+    static $wildcards = array();
+    $matching = array();
+
+    if (!is_string($cid) && !is_int($cid)) {
+      register_shutdown_function('watchdog', 'memcache', 'Invalid cache id received in memcache.inc wildcards() of type !type.', array('!type' => gettype($cid)), WATCHDOG_ERROR);
+      return $matching;
+    }
+    $length = strlen($cid);
+
+    if (isset($this->wildcard_flushes[$this->bin]) && is_array($this->wildcard_flushes[$this->bin])) {
+      // Wildcard flushes per table are keyed by a substring equal to the
+      // shortest wildcard clear on the table so far. So if the shortest
+      // wildcard was "links:foo:", and the cid we're checking for is
+      // "links:bar:bar", then the key will be "links:bar:".
+      $keys = array_keys($this->wildcard_flushes[$this->bin]);
+      $wildcard_length = strlen(reset($keys));
+      $wildcard_key = substr($cid, 0, $wildcard_length);
+
+      // Determine which lookups we need to perform to determine whether or not
+      // our cid was impacted by a wildcard flush.
+      $lookup = array();
+
+      // Find statically cached wildcards, and determine possibly matching
+      // wildcards for this cid based on a history of the lengths of past
+      // valid wildcard flushes in this bin.
+      if (isset($this->wildcard_flushes[$this->bin][$wildcard_key])) {
+        foreach ($this->wildcard_flushes[$this->bin][$wildcard_key] as $flush_length => $timestamp) {
+          if ($length >= $flush_length && $timestamp >= (REQUEST_TIME - $this->invalidate)) {
+            $wildcard = '.wildcard-' . substr($cid, 0, $flush_length);
+            if (isset($wildcards[$this->bin][$wildcard])) {
+              $matching[$wildcard] = $wildcards[$this->bin][$wildcard];
+            }
+            else {
+              $lookup[$wildcard] = $wildcard;
+            }
+          }
+        }
+      }
+
+      // Do a multi-get to retrieve all possibly matching wildcard flushes.
+      if (!empty($lookup)) {
+        $values = dmemcache_get_multi($lookup, $this->bin, $this->memcache);
+        if (is_array($values)) {
+          // Prepare an array of matching wildcards.
+          $matching = array_merge($matching, $values);
+          // Store matches in the static cache.
+          if (isset($wildcards[$this->bin])) {
+            $wildcards[$this->bin] = array_merge($wildcards[$this->bin], $values);
+          }
+          else {
+            $wildcards[$this->bin] = $values;
+          }
+          $lookup = array_diff_key($lookup, $values);
+        }
+
+        // Also store failed lookups in our static cache, so we don't have to
+        // do repeat lookups on single page loads.
+        foreach ($lookup as $key => $key) {
+          $wildcards[$this->bin][$key] = 0;
+        }
+      }
+    }
+
+    if ($flush) {
+      $key_length = $length;
+      if (isset($this->wildcard_flushes[$this->bin])) {
+        $keys = array_keys($this->wildcard_flushes[$this->bin]);
+        $key_length = strlen(reset($keys));
+      }
+      $key = substr($cid, 0, $key_length);
+      // Avoid too many calls to variable_set() by only recording a flush for
+      // a fraction of the wildcard invalidation variable, per cid length.
+      // Defaults to 28 / 4, or one week.
+      if (!isset($this->wildcard_flushes[$this->bin][$key][$length]) || (REQUEST_TIME - $this->wildcard_flushes[$this->bin][$key][$length] > $this->invalidate / 4)) {
+
+        // If there are more than 50 different wildcard keys for this bin
+        // shorten the key by one, this should reduce variability by
+        // an order of magnitude and ensure we don't use too much memory.
+        if (isset($this->wildcard_flushes[$this->bin]) && count($this->wildcard_flushes[$this->bin]) > 50) {
+          $key = substr($cid, 0, $key_length - 1);
+          $length = strlen($key);
+        }
+
+        // If this is the shortest key length so far, we need to remove all
+        // other wildcards lengths recorded so far for this bin and start
+        // again. This is equivalent to a full cache flush for this table, but
+        // it ensures the minimum possible number of wildcards are requested
+        // along with cache consistency.
+        if ($length < $key_length) {
+          $this->wildcard_flushes[$this->bin] = array();
+          $this->variable_set("cache_flush_$this->bin", time());
+          $this->cache_flush = time();
+        }
+        $key = substr($cid, 0, $key_length);
+        $this->wildcard_flushes[$this->bin][$key][$length] = REQUEST_TIME;
+
+        variable_set('memcache_wildcard_flushes', $this->wildcard_flushes);
+      }
+      $key = '.wildcard-' . $cid;
+      if (isset($wildcards[$this->bin][$key])) {
+        $wildcards[$this->bin][$key]++;
+      }
+      else {
+        $wildcards[$this->bin][$key] = 1;
+      }
+      dmemcache_set($key, $wildcards[$this->bin][$key], 0, $this->bin);
+    }
+    return $matching;
+  }
+
+  /**
+   * Check if a wildcard flush has invalidated the current cached copy.
+   */
+  protected function wildcardValid($cid, $cache) {
+    // Previously cached content won't have ->flushes defined.  We could
+    // force flush, but instead leave this up to the site admin.
+    $flushes = isset($cache->flushes) ? (int) $cache->flushes : 0;
+    if ($flushes < (int) $this->wildcardFlushes($cid)) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Implements DrupalCacheInterface::isEmpty().
+   */
+  public function isEmpty() {
+    // We do not know so err on the safe side?
+    return FALSE;
+  }
+
+  /**
+   * Helper function to load locking framework if not already loaded.
+   *
+   * @return bool
+   *   Whether the locking system was initialized successfully. This must always
+   *   return TRUE or throw an exception.
+   */
+  public function lockInit() {
+    // On a cache miss when page_cache_without_database is enabled, we can end
+    // up here without the lock system being initialized. Bootstrap drupal far
+    // enough to load the lock system.
+    if (!function_exists('lock_acquire')) {
+      drupal_bootstrap(DRUPAL_BOOTSTRAP_VARIABLES, FALSE);
+    }
+
+    if (!function_exists('lock_acquire')) {
+      // Bootstrap failed, log error.
+      register_shutdown_function('watchdog', 'memcache', 'Bootstrap failed in lockInit(), lock_acquire() is not available. (phase:!phase)', array('!phase' => drupal_get_bootstrap_phase()), WATCHDOG_ERROR);
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Determines whether stampede protection is enabled for a given bin/cid.
+   *
+   * Memcache stampede protection is primarily designed to benefit the following
+   * caching pattern: a miss on a cache_get for a specific cid is immediately
+   * followed by a cache_set for that cid. In cases where this pattern is not
+   * followed, stampede protection can be disabled to avoid long hanging locks.
+   * For example, a cache miss in Drupal core's module_implements() won't
+   * execute a cache_set until drupal_page_footer() calls
+   * module_implements_write_cache() which can occur much later in page
+   * generation.
+   *
+   * @param string $cid
+   *   The cache id of the data to retrieve.
+   *
+   * @return bool
+   *   Returns TRUE if stampede protection is enabled for that particular cache
+   *   bin/cid, otherwise FALSE.
+   */
+  protected function stampedeProtected($cid) {
+    $ignore_settings = variable_get('memcache_stampede_protection_ignore', array(
+      // Disable stampede protection for specific cids in 'cache_bootstrap'.
+      'cache_bootstrap' => array(
+        // The module_implements cache is written after finishing the request.
+        'module_implements',
+        // Variables have their own lock protection.
+        'variables',
+        // Delayed set.
+        'lookup_cache',
+        // Both schema and the theme_registry uses DrupalCacheArray, which sets
+        // the cache entry with a class destructor.
+        'schema:runtime:*',
+        'theme_registry:runtime:*',
+        // Not written until the end of drupal_page_footer()
+        '_drupal_file_scan_cache',
+      ),
+      // Disable stampede protection for cid prefix in 'cache'.
+      'cache' => array(
+        // I18n uses a class destructor to set the cache.
+        'i18n:string:*',
+      ),
+      // Delayed set.
+      'cache_path',
+      // Disable stampede protection for the contrib cache_rules bin as recent
+      // versions of the rules module provides its own stampede protection.
+      'cache_rules',
+    ));
+
+    // Support ignoring an entire bin.
+    if (in_array($this->bin, $ignore_settings)) {
+      return FALSE;
+    }
+
+    // Support ignoring by cids.
+    if (isset($ignore_settings[$this->bin])) {
+      // Support ignoring specific cids.
+      if (in_array($cid, $ignore_settings[$this->bin])) {
+        return FALSE;
+      }
+      // Support ignoring cids starting with a suffix.
+      foreach ($ignore_settings[$this->bin] as $ignore) {
+        $split = explode('*', $ignore);
+        if (count($split) > 1 && strpos($cid, $split[0]) === 0) {
+          return FALSE;
+        }
+      }
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Helper function to reload variables.
+   *
+   * This is used by the tests to verify that the cache object used the correct
+   * settings.
+   */
+  public function reloadVariables() {
+    $this->wildcard_flushes = variable_get('memcache_wildcard_flushes', array());
+    $this->invalidate = variable_get('memcache_wildcard_invalidate', MEMCACHE_WILDCARD_INVALIDATE);
+    $this->cache_lifetime = variable_get('cache_lifetime_' . $this->bin, variable_get('cache_lifetime', 0));
+    $this->cache_flush = variable_get('cache_flush_' . $this->bin);
+    $this->cache_content_flush = variable_get('cache_content_flush_' . $this->bin, 0);
+    $this->cache_temporary_flush = variable_get('cache_temporary_flush_' . $this->bin, 0);
+    $this->flushed = min($this->cache_flush, REQUEST_TIME - $this->cache_lifetime);
+  }
+
+  /**
+   * Re-implementation of variable_set() that writes through instead of clearing.
+   */
+  public function variable_set($name, $value) {
+    global $conf;
+
+    // If the value appears unchanged, do nothing.
+    if (isset($conf[$name]) && $conf[$name] === $value) {
+      return;
+    }
+
+    // When lots of writes happen in a short period of time db_merge can throw
+    // errors. This should only happen if another request has written the
+    // variable first, so we catch the error to prevent a fatal error.
+    try {
+      db_merge('variable')
+        ->key(array('name' => $name))
+        ->fields(array('value' => serialize($value)))
+        ->execute();
+    }
+    catch (Exception $e) {
+      // We can safely ignore the error, since it's likely a cache flush
+      // timestamp which should still be accurate.
+    }
+
+    // If the variables are cached, get a fresh copy, update with the new value
+    // and set it again.
+    if ($cached = cache_get('variables', 'cache_bootstrap')) {
+      $variables = $cached->data;
+      $variables[$name] = $value;
+      cache_set('variables', $variables, 'cache_bootstrap');
+    }
+    // If the variables aren't cached, there's no need to do anything.
+    $conf[$name] = $value;
+  }
+}

--- a/html/sites/all/modules/contrib/memcache/memcache.info
+++ b/html/sites/all/modules/contrib/memcache/memcache.info
@@ -1,0 +1,13 @@
+name = Memcache
+description = High performance integration with memcache.
+package = Performance and scalability
+core = 7.x
+files[] = memcache.inc
+files[] = tests/memcache.test
+files[] = tests/memcache-lock.test
+
+; Information added by Drupal.org packaging script on 2020-07-17
+version = "7.x-1.8"
+core = "7.x"
+project = "memcache"
+datestamp = "1594981708"

--- a/html/sites/all/modules/contrib/memcache/memcache.install
+++ b/html/sites/all/modules/contrib/memcache/memcache.install
@@ -1,0 +1,350 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the memcache module.
+ */
+
+define('MEMCACHE_PECL_RECOMMENDED', '3.0.6');
+define('MEMCACHE_PECL_PHP7_RECOMMENDED', '4.0.5');
+define('MEMCACHED_PECL_RECOMMENDED', '2.0.1');
+define('MEMCACHED_ASCII_AUTH_MINIMUM', '1.5.15');
+define('MEMCACHED_ASCII_AUTH_RECOMMENDED', '1.6.4');
+
+/**
+ * Implements hook_enable().
+ */
+function memcache_enable() {
+  $error = FALSE;
+  $warning = FALSE;
+  $severity = 'status';
+  $memcache = extension_loaded('memcache');
+  $memcached = extension_loaded('memcached');
+  if (!$memcache && !$memcached) {
+    $error = TRUE;
+  }
+  if (!function_exists('dmemcache_object')) {
+    // dmemcache.inc isn't loaded.
+    $error = TRUE;
+  }
+  else {
+    if (!_memcache_pecl_version_valid()) {
+      $warning = TRUE;
+    }
+    // If ASCII protocol authentication is enabled, perform extra tests.
+    if (_dmemcache_use_ascii_auth()) {
+      // Verify minimum required memcached version for ASCII protocol authentication is installed.
+      $version = _memcached_ascii_auth_version_valid(MEMCACHED_ASCII_AUTH_MINIMUM);
+      // TRUE means version valid, FALSE means we failed to connect and will throw a different error.
+      if ($version !== TRUE && $version !== FALSE) {
+        $error = TRUE;
+      }
+      else {
+        $version = _memcached_ascii_auth_version_valid(MEMCACHED_ASCII_AUTH_RECOMMENDED);
+        // TRUE means version valid, FALSE means we failed to connect and will throw a different error.
+        if ($version !== TRUE && $version !== FALSE) {
+          $warning = TRUE;
+        }
+      }
+    }
+    // Make a test connection to all configured memcache servers.
+    $memcache_servers = variable_get('memcache_servers', array('127.0.0.1:11211' => 'default'));
+    foreach ($memcache_servers as $server => $bin) {
+      if ($cluster = dmemcache_object_cluster($bin)) {
+        $memcache = dmemcache_instance($cluster['cluster']);
+        if (dmemcache_connect($memcache, $server, $cluster['weight']) === FALSE) {
+          $error = TRUE;
+        }
+        else {
+          if (!variable_get('memcache_persistent', TRUE)) {
+            dmemcache_close($memcache);
+          }
+        }
+      }
+    }
+  }
+
+  if ($error) {
+    $severity = 'error';
+  }
+  elseif ($warning) {
+    $severity = 'warning';
+  }
+
+  if ($error || $warning) {
+    drupal_set_message(t('There are problems with your Memcache configuration. Please review %readme and visit the Drupal admin !status page for more information.', array('%readme' => 'README.txt', '!status' => l(t('status report'), 'admin/reports/status'))), $severity);
+  }
+
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function memcache_requirements($phase) {
+  $requirements = array();
+  $t = get_t();
+  $memcache = extension_loaded('memcache');
+  $memcached = extension_loaded('memcached');
+
+  if ($phase == 'install' || $phase == 'runtime') {
+    $requirements['memcache_extension']['title'] = $t('Memcache');
+    if (!$memcache && !$memcached) {
+      $requirements['memcache_extension']['severity'] = REQUIREMENT_ERROR;
+      $requirements['memcache_extension']['value'] = $t('Required PHP extension not found. Install the <a href="http://php.net/manual/en/book.memcache.php">memcache</a> (recommended) or <a href="http://php.net/manual/en/book.memcached.php">memcached</a> extension.');
+    }
+    else {
+      $requirements['memcache_extension']['value'] = $t('PHP %extension Extension', array('%extension' => $memcache ? $t('Memcache') : $t('Memcached')));
+    }
+  }
+  if ($phase == 'runtime') {
+    $errors = array();
+    $warnings = array();
+
+    if (!$memcache && !$memcached) {
+      $errors[] = $t('Required PHP extension not found. Install the <a href="http://php.net/manual/en/book.memcache.php">memcache</a> (recommended) or <a href="http://php.net/manual/en/book.memcached.php">memcached</a> extension.');
+    }
+
+    if (!function_exists('dmemcache_set')) {
+      // dmemcache.inc isn't loaded.
+      $errors[] = $t('Failed to load required file %dmemcache.', array('%dmemcache' => drupal_get_path('module', 'memcache') . '/' . 'dmemcache.inc'));
+      $requirements['memcache_extension']['value'] = $t('Unknown');
+    }
+    else {
+      $extension = dmemcache_extension();
+      if ($extension == 'Memcache') {
+        $version = phpversion('memcache');
+        if (version_compare(phpversion(), '7', '>=')) {
+          $recommended = MEMCACHE_PECL_PHP7_RECOMMENDED;
+        }
+        else {
+          $recommended = MEMCACHE_PECL_RECOMMENDED;
+        }
+      }
+      elseif ($extension == 'Memcached') {
+        $version = phpversion('memcached');
+        $recommended = MEMCACHED_PECL_RECOMMENDED;
+      }
+      if (!$version) {
+        $version = $t('Unknown');
+      }
+      $requirements['memcache_extension']['value'] = $version . _memcache_statistics_link();
+
+      if (!_memcache_pecl_version_valid()) {
+        $warnings[] = $t('PECL !extension version %version is unsupported. Please update to %recommended or newer.', array(
+          '!extension' => $extension,
+          '%version' => $version,
+          '%recommended' => $recommended,
+        ));
+      }
+
+      // If ASCII protocol authentication is enabled, perform extra tests.
+      if (_dmemcache_use_ascii_auth()) {
+        // Verify minimum required memcached version for ASCII protocol authentication is installed.
+        $version = _memcached_ascii_auth_version_valid(MEMCACHED_ASCII_AUTH_MINIMUM);
+        // TRUE means version valid, FALSE means we failed to connect and will throw a different error.
+        if ($version !== TRUE && $version !== FALSE) {
+          $errors[] = $t('ASCII protocol authentication is enabled but requires memcached v%minimum or greater. One or more memcached instances detected running memcache v%version.' . _memcache_statistics_link(), array(
+            '%version' => $version,
+            '%minimum' => MEMCACHED_ASCII_AUTH_MINIMUM,
+          ));
+        }
+        else {
+          $version = _memcached_ascii_auth_version_valid(MEMCACHED_ASCII_AUTH_RECOMMENDED);
+          // TRUE means version valid, FALSE means we failed to connect and will throw a different error.
+          if ($version !== TRUE && $version !== FALSE) {
+            $warnings[] = $t('Memcached v%recommended is recommended when using ASCII protocol authentication, to avoid a CPU race. One or more memcached instances detected are running memcache v%version.' . _memcache_statistics_link(), array(
+              '%version' => $version,
+              '%recommended' => MEMCACHED_ASCII_AUTH_RECOMMENDED,
+            ));
+          }
+        }
+
+        // Confirm ASCII authentication works on all memcached servers.
+        $memcache_bins = variable_get('memcache_bins', array('cache' => 'default'));
+        foreach ($memcache_bins as $bin => $_) {
+          if ($mc = dmemcache_object($bin)) {
+            $ascii_auth = _check_ascii_auth($mc);
+            if ($ascii_auth !== TRUE) {
+              $s = $ascii_auth[0];
+              $message = $ascii_auth[1];
+
+              $errors[] = $t('ASCII protocol authentication failed: %message (%host:%port).' . _memcache_statistics_link(), array(
+                '%host' => $s['host'],
+                '%port' => $s['port'],
+                '%message' => $message,
+              ));
+            }
+          }
+        }
+      }
+
+      // Make a test connection to all configured memcache servers.
+      $memcache_servers = variable_get('memcache_servers', array('127.0.0.1:11211' => 'default'));
+      foreach ($memcache_servers as $server => $bin) {
+        if ($cluster = dmemcache_object_cluster($bin)) {
+          $memcache = dmemcache_instance($cluster['cluster']);
+          if (dmemcache_connect($memcache, $server, $cluster['weight']) === FALSE) {
+            $errors[] = $t('Failed to connect to memcached server instance at %server.', array('%server' => $server));
+          }
+          else {
+            if (!variable_get('memcache_persistent', TRUE)) {
+              dmemcache_close($memcache);
+            }
+          }
+        }
+      }
+
+      // Set up a temporary bin to see if we can store a value and then
+      // successfully retreive it.
+      try {
+        $cid = 'memcache_requirements_test';
+        $value = 'OK';
+        // Temporarily store a test value in memcache.
+        cache_set($cid, $value);
+        // Retreive the test value from memcache.
+        $data = cache_get($cid);
+        if (!isset($data->data) || $data->data !== $value) {
+          $errors[] = $t('Failed to store to then retrieve data from memcache.');
+        }
+        else {
+          // Test a delete as well.
+          cache_clear_all($cid, 'cache');
+        }
+      }
+      catch (Exception $e) {
+        // An unexpected exception occurred.
+        $errors[] = $t('Unexpected failure when testing memcache configuration.');
+      }
+      // Core's lock implementation can cause worse performance together with
+      // stampede protection. Plus, long keys will be truncated resulting in
+      // dropped locks.
+      if (variable_get('memcache_stampede_protection', FALSE) && strpos(variable_get('lock_inc', 'includes/lock.inc'), 'includes/lock.inc') !== FALSE) {
+        $warnings[] = $t('Drupal\'s core lock implementation (%core) is not supported by memcache stampede protection. Enable the memcache lock implementation (%memcache) or disable memcache stampede protection.', array('%core' => 'includes/lock.inc', '%memcache' => drupal_get_path('module', 'memcache') . "/memcache-lock.inc"));
+      }
+    }
+
+    if (!empty($errors)) {
+      // Error takes precedence over warning, stack together errors and
+      // warnings and display as error messages.
+      $errors = array_merge($errors, $warnings);
+      unset($warnings);
+      $requirements['memcache_extension']['severity'] = REQUIREMENT_ERROR;
+      $requirements['memcache_extension']['description'] = $t('There is a problem with your memcache configuration, check the Drupal logs for additional errors. Please review %readme for help resolving the following !issue: !errors', array('%readme' => drupal_get_path('module', 'memcache') . '/' . 'README.txt', '!issue' => format_plural(count($errors), 'issue', 'issues'), '!errors' => '<ul><li>' . implode('<li>', $errors)));
+    }
+    elseif (!empty($warnings)) {
+      $requirements['memcache_extension']['severity'] = REQUIREMENT_WARNING;
+      $requirements['memcache_extension']['description'] = $t('There is a problem with your memcache configuration. Please review %readme for help resolving the following !issue: !warnings', array('%readme' => drupal_get_path('module', 'memcache') . '/' . 'README.txt', '!issue' => format_plural(count($warnings), 'issue', 'issues'), '!warnings' => '<ul><li>' . implode('<li>', $warnings)));
+    }
+    else {
+      $requirements['memcache_extension']['severity'] = REQUIREMENT_OK;
+    }
+  }
+  return $requirements;
+}
+
+/**
+ * Add "(more information)" link after memcache version if memcache_admin
+ * module is enabled and user has access to memcache statistics.
+ */
+function _memcache_statistics_link() {
+  $t = get_t();
+  if (module_exists('memcache_admin') && user_access('access memcache statistics')) {
+    return ' (' . l($t('more information'), 'admin/reports/memcache') . ')';
+  }
+  else {
+    return '';
+  }
+}
+
+/**
+ * Validate whether the current PECL version is supported.
+ */
+function _memcache_pecl_version_valid() {
+  $extension = dmemcache_extension();
+  if ($extension == 'Memcache') {
+    // The latest PECL Memcache releases are using a 4 digit version
+    // which version_compare doesn't support. At this time the 4th
+    // digit isn't important to us, so we just look at the first 3
+    // digits. If a future release requires 4 digit precision
+    // it will require a replacement for version_compare().
+    $full_version = phpversion('memcache');
+    $version = implode('.', array_slice(explode('.', $full_version), 0, 3));
+    if (version_compare(phpversion(), '7'. '>=')) {
+      return version_compare($version, MEMCACHE_PECL_PHP7_RECOMMENDED, '>=');
+    }
+    else {
+      return version_compare($version, MEMCACHE_PECL_RECOMMENDED, '>=');
+    }
+  }
+  elseif ($extension == 'Memcached') {
+    return version_compare(phpversion('memcached'), MEMCACHED_PECL_RECOMMENDED, '>=');
+  }
+}
+
+/**
+ * If ASCII protocol authentication is enabled, validate whether the current memcached
+ * version meets the minimum and/or recommended requirements.
+ */
+function _memcached_ascii_auth_version_valid($version) {
+  if (_dmemcache_use_ascii_auth()) {
+    $stats = dmemcache_stats();
+    foreach ($stats as $bin => $servers) {
+      if (!empty($servers)) {
+        foreach ($servers as $server => $value) {
+          $installed_version = $value['version'];
+          if (version_compare($installed_version, $version, '<')) {
+            // Return detected invalid version of memcached.
+            return $installed_version;
+          }
+        }
+      }
+      else {
+        return FALSE;
+      }
+    }
+  }
+  // Fall through if no unsupported version of memcached was detected, or ascii auth is
+  // not enabled.
+  return TRUE;
+}
+
+/**
+ * Check that ascii authentication is setup correctly.
+ *
+ * @param string $memcache_original
+ *   The memcache object whose servers will be checked.
+ *
+ * @return TRUE|array
+ *   TRUE on success, the failed server and the error message
+ *   on failure.
+ */
+function _check_ascii_auth($memcache_original) {
+  $servers = $memcache_original->getServerList();
+  foreach ($servers as $s) {
+    // Note: This intentionally does not use a persistent id.
+    $mc = new Memcached();
+    $mc->addServer($s['host'], $s['port']);
+
+    // Check that a set() / get() with a fresh connection fails.
+    $mc->set(DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY, TRUE);
+    $rc = $mc->get(DRUPAL_MEMCACHE_ASCII_AUTH_LIFETIME_KEY);
+    if ($rc) {
+      return [$s, t('ASCII authentication not enabled on server')];
+    }
+
+    $rc = _dmemcache_ensure_ascii_auth("0", $mc);
+    if (!$rc) {
+      return [$s, t('ASCII authentication failed')];
+    }
+  }
+
+  return TRUE;
+}
+
+
+/**
+ * Remove the memcache_widlcard_flushes variable since its structure has changed.
+ */
+function memcache_update_7000() {
+  variable_del('memcache_wildcard_flushes');
+}

--- a/html/sites/all/modules/contrib/memcache/memcache.module
+++ b/html/sites/all/modules/contrib/memcache/memcache.module
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Provides very limited functionality such as hook_requirements().
+ *
+ * memcache.inc must be configured in settings.php, and memcache.module is not
+ * necessary to use memcache as a cache backend.
+ */

--- a/html/sites/all/modules/contrib/memcache/memcache_admin/memcache.js
+++ b/html/sites/all/modules/contrib/memcache/memcache_admin/memcache.js
@@ -1,0 +1,21 @@
+/**
+ * @file
+ * Defines the behavior of the Memcache Admin module.
+ */
+
+(function ($) {
+
+  'use strict';
+
+  /**
+   * Append the memcache debug info to the page.
+   *
+   * @type {Drupal~behavior}
+   */
+  Drupal.behaviors.memcacheAdmin = {
+    attach: function attach() {
+      $("body").append($("#memcache-devel"));
+    }
+  };
+
+})(jQuery);

--- a/html/sites/all/modules/contrib/memcache/memcache_admin/memcache_admin.info
+++ b/html/sites/all/modules/contrib/memcache/memcache_admin/memcache_admin.info
@@ -1,0 +1,11 @@
+name = Memcache Admin
+description = Adds a User Interface to monitor the Memcache for this site.
+core = 7.x
+package = Performance and scalability
+configure = admin/config/system/memcache
+
+; Information added by Drupal.org packaging script on 2020-07-17
+version = "7.x-1.8"
+core = "7.x"
+project = "memcache"
+datestamp = "1594981708"

--- a/html/sites/all/modules/contrib/memcache/memcache_admin/memcache_admin.install
+++ b/html/sites/all/modules/contrib/memcache/memcache_admin/memcache_admin.install
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Update functions for memcache_admin.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function memcache_admin_requirements($phase) {
+  // Ensure translations don't break during installation.
+  $t = get_t();
+
+  $requirements = array();
+
+  if ($phase == 'install') {
+    if (!function_exists('dmemcache_object_cluster')) {
+      $requirements['memcache_admin'] = array(
+        'title' => $t('Memcache admin'),
+        'value' => $t('cache_backends not properly configured in settings.php, failed to load required file memcache.inc.'),
+        'description' => $t('You must properly configure cache_backends in %settings before enabling the memcache_admin module. Please review %readme for more information.', array('%settings' => 'settings.php', '%readme' => 'README.txt')),
+        'severity' => REQUIREMENT_ERROR,
+      );
+    }
+  }
+  else if ($phase == 'runtime') {
+    if (!function_exists('dmemcache_object_cluster') && module_exists('memcache_admin')) {
+      $requirements['memcache_admin'] = array(
+        'title' => $t('Memcache admin'),
+        'value' => $t('cache_backends not properly configured in settings.php, failed to load required file memcache.inc.'),
+        'description' => $t('You have enabled the memcache_admin module without properly configuring cache_backends in %settings. Please review %readme for more information.', array('%settings' => 'settings.php', '%readme' => 'README.txt')),
+        'severity' => REQUIREMENT_WARNING,
+      );
+    }
+  }
+  return $requirements;
+}
+
+/**
+ * Flush caches and rebuild menu to allow new stats pages to appear.
+ */
+function memcache_admin_update_7001() {
+  drupal_flush_all_caches();
+  menu_rebuild();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function memcache_admin_uninstall() {
+  variable_del('show_memcache_statistics');
+}

--- a/html/sites/all/modules/contrib/memcache/memcache_admin/memcache_admin.module
+++ b/html/sites/all/modules/contrib/memcache/memcache_admin/memcache_admin.module
@@ -1,0 +1,772 @@
+<?php
+
+/**
+ * @file
+ * For the collection and display of memcache stats.
+ *
+ * This module adds a small .js file to makes sure that the HTML displaying the
+ * stats is inside of the <body> part of the HTML document.
+ */
+
+/**
+ * Implements hook_init().
+ */
+function memcache_admin_init() {
+  global $user;
+  if (($user->uid == 0) || strstr($_SERVER['PHP_SELF'], 'update.php') || (isset($_GET['q']) && (in_array($_GET['q'], array('upload/js', 'admin/content/node-settings/rebuild')) || substr($_GET['q'], 0, strlen('system/files')) == 'system/files' || substr($_GET['q'], 0, strlen('batch')) == 'batch' || strstr($_GET['q'], 'autocomplete')))) {
+    // update.php relies on standard error handler.
+  }
+  else {
+    if ($user->uid) {
+      drupal_add_js(drupal_get_path('module', 'memcache_admin') . '/memcache.js');
+    }
+    register_shutdown_function('memcache_admin_shutdown');
+  }
+}
+
+/**
+ * Implements hook_perm().
+ */
+function memcache_admin_permission() {
+  return array(
+    'access memcache statistics' => array(
+      'title' => t('Access memcache statistics'),
+    ),
+    'access slab cachedump' => array(
+      'title' => t('Access cachedump of memcache slab'),
+      'restrict access' => TRUE,
+    ),
+  );
+}
+
+/**
+ * Implements hook_menu().
+ */
+function memcache_admin_menu() {
+  $items['admin/config/system/memcache'] = array(
+    'title' => 'Memcache',
+    'description' => 'Show or hide memcache statistics at the bottom of each page.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('memcache_admin_admin_settings'),
+    'access arguments' => array('administer site configuration'),
+  );
+  $items['admin/reports/memcache'] = array(
+    'title' => 'Memcache statistics',
+    'description' => "View statistics for all configured memcache servers.",
+    'page callback' => 'memcache_admin_stats',
+    'access arguments' => array('access memcache statistics'),
+    'weight' => 1,
+  );
+  $memcache_servers = variable_get('memcache_servers', array('127.0.0.1:11211' => 'default'));
+  $clusters = array();
+  foreach ($memcache_servers as $server => $bin) {
+    if (function_exists('dmemcache_object_cluster') && $cluster = dmemcache_object_cluster($bin)) {
+      $name = $cluster['cluster'];
+      $clusters[$name]['servers'][] = $server;
+      $clusters[$name]['bin'] = _memcache_admin_get_bin_for_cluster($cluster['cluster']);
+    }
+  }
+
+  $count = 0;
+  foreach ($clusters as $cluster => $cluster_info) {
+    if ($cluster_info['bin']) {
+      if (empty($current_cluster)) {
+        $current_cluster = arg(3);
+        if (empty($current_cluster)) {
+          $current_cluster = $cluster;
+        }
+      }
+
+      $items["admin/reports/memcache/$cluster"] = array(
+        'title' => $cluster,
+        'type' => $count == 0 ? MENU_DEFAULT_LOCAL_TASK : MENU_LOCAL_TASK,
+        'page callback' => 'memcache_admin_stats',
+        'page arguments' => array($cluster),
+        'access arguments' => array('access memcache statistics'),
+        'weight' => $count++,
+      );
+      foreach ($cluster_info['servers'] as $server) {
+        $items["admin/reports/memcache/$cluster/$server"] = array(
+          'title' => check_plain($server),
+          'type' => MENU_CALLBACK,
+          'page callback' => 'memcache_admin_stats_raw',
+          'page arguments' => array($cluster, $server),
+          'access arguments' => array('access memcache statistics'),
+        );
+        foreach (memcache_admin_stats_types($cluster) as $type) {
+          $items["admin/reports/memcache/$cluster/$server/$type"] = array(
+            'type' => MENU_CALLBACK,
+            'page callback' => 'memcache_admin_stats_raw',
+            'page arguments' => array($cluster, $server, $type),
+            'title' => $type,
+            'access arguments' => array('access memcache statistics'),
+          );
+        }
+      }
+    }
+  }
+
+  return $items;
+}
+
+/**
+ * Settings form.
+ */
+function memcache_admin_admin_settings() {
+  $form['show_memcache_statistics'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show memcache statistics at the bottom of each page'),
+    '#default_value' => variable_get('show_memcache_statistics', FALSE),
+    '#description' => t("These statistics will be visible to users with the 'access memcache statistics' permission."),
+  );
+  return system_settings_form($form);
+}
+
+/**
+ * Helper function. Returns the bin name.
+ */
+function _memcache_admin_default_bin($bin) {
+  if ($bin == 'default') {
+    return 'cache';
+  }
+  return $bin;
+}
+
+/**
+ * Statistics report: format total and open connections.
+ */
+function _memcache_admin_stats_connections($stats) {
+  return t('!current open of !total total', array('!current' => number_format($stats['curr_connections']), '!total' => number_format($stats['total_connections'])));
+}
+
+/**
+ * Statistics report: calculate # of set cmds and total cmds.
+ */
+function _memcache_admin_stats_sets($stats) {
+  if (($stats['cmd_set'] + $stats['cmd_get']) == 0) {
+    $sets = 0;
+  }
+  else {
+    $sets = $stats['cmd_set'] / ($stats['cmd_set'] + $stats['cmd_get']) * 100;
+  }
+  if (empty($stats['uptime'])) {
+    $average = 0;
+  }
+  else {
+    $average = $sets / $stats['uptime'];
+  }
+  return t('!average/s; !set sets (!sets%) of !total commands', array('!average' => number_format($average, 2), '!sets' => number_format($sets, 2), '!set' => number_format($stats['cmd_set']), '!total' => number_format($stats['cmd_set'] + $stats['cmd_get'])));
+}
+
+/**
+ * Statistics report: calculate # of get cmds, broken down by hits and misses.
+ */
+function _memcache_admin_stats_gets($stats) {
+  if (($stats['cmd_set'] + $stats['cmd_get']) == 0) {
+    $gets = 0;
+  }
+  else {
+    $gets = $stats['cmd_get'] / ($stats['cmd_set'] + $stats['cmd_get']) * 100;
+  }
+  if (empty($stats['uptime'])) {
+    $average = 0;
+  }
+  else {
+    $average = $stats['cmd_get'] / $stats['uptime'];
+  }
+  return t('!average/s; !total gets (!gets%); !hit hits (!percent_hit%) !miss misses (!percent_miss%)', array('!average' => number_format($average, 2), '!gets' => number_format($gets, 2), '!hit' => number_format($stats['get_hits']), '!percent_hit' => ($stats['cmd_get'] > 0 ? number_format($stats['get_hits'] / $stats['cmd_get'] * 100, 2) : '0.00'), '!miss' => number_format($stats['get_misses']), '!percent_miss' => ($stats['cmd_get'] > 0 ? number_format($stats['get_misses'] / $stats['cmd_get'] * 100, 2) : '0.00'), '!total' => number_format($stats['cmd_get'])));
+}
+
+/**
+ * Statistics report: calculate # of increments and decrements.
+ */
+function _memcache_admin_stats_counters($stats) {
+  if (!is_array($stats)) {
+    $stats = array();
+  }
+  $stats += array(
+    'incr_hits' => 0,
+    'incr_misses' => 0,
+    'decr_hits' => 0,
+    'decr_misses' => 0,
+  );
+  return t('!incr increments, !decr decrements', array('!incr' => number_format($stats['incr_hits'] + $stats['incr_misses']), '!decr' => number_format($stats['decr_hits'] + $stats['decr_misses'])));
+}
+
+/**
+ * Statistics report: calculate bytes transferred.
+ */
+function _memcache_admin_stats_transfer($stats) {
+  if ($stats['bytes_written'] == 0) {
+    $written = 0;
+  }
+  else {
+    $written = $stats['bytes_read'] / $stats['bytes_written'] * 100;
+  }
+  return t('!to:!from (!written% to cache)', array('!to' => format_size((int) $stats['bytes_read']), '!from' => format_size((int) $stats['bytes_written']), '!written' => number_format($written, 2)));
+}
+
+/**
+ * Statistics report: calculate per-connection averages.
+ */
+function _memcache_admin_stats_average($stats) {
+  if ($stats['total_connections'] == 0) {
+    $get = 0;
+    $set = 0;
+    $read = 0;
+    $write = 0;
+  }
+  else {
+    $get = $stats['cmd_get'] / $stats['total_connections'];
+    $set = $stats['cmd_set'] / $stats['total_connections'];
+    $read = $stats['bytes_written'] / $stats['total_connections'];
+    $write = $stats['bytes_read'] / $stats['total_connections'];
+  }
+  return t('!read in !get gets; !write in !set sets', array('!get' => number_format($get, 2), '!set' => number_format($set, 2), '!read' => format_size(number_format($read, 2)), '!write' => format_size(number_format($write, 2))));
+}
+
+/**
+ * Statistics report: calculate available memory.
+ */
+function _memcache_admin_stats_memory($stats) {
+  if ($stats['limit_maxbytes'] == 0) {
+    $percent = 0;
+  }
+  else {
+    $percent = 100 - $stats['bytes'] / $stats['limit_maxbytes'] * 100;
+  }
+  return t('!available (!percent%) of !total', array('!available' => format_size($stats['limit_maxbytes'] - $stats['bytes']), '!percent' => number_format($percent, 2), '!total' => format_size($stats['limit_maxbytes'])));
+}
+
+/**
+ * Helper function, reverse map the memcache_bins variable.
+ */
+function memcache_admin_bin_mapping($bin = 'cache') {
+  $bins = array_flip(variable_get('memcache_bins', array('cache' => 'default')));
+  if (isset($bins[$bin])) {
+    return $bins[$bin];
+  }
+  else {
+    // The default bin is 'cache'.
+    return _memcache_admin_default_bin($bin);
+  }
+}
+
+/**
+ * Callback for the Memcache Stats page.
+ *
+ * @return string
+ *   The page output.
+ */
+function memcache_admin_stats($bin = 'default') {
+  if (!class_exists('MemCacheDrupal', FALSE)) {
+    return t('There is a problem with your memcache configuration. Please review !readme for help resolving the following issue: %error.', array('!readme' => l('README.txt', 'http://cgit.drupalcode.org/memcache/tree/README.txt?id=refs/heads;id2=7.x-1.x'), '%error' => t('cache_backends not properly configured in settings.php, failed to load required file memcache.inc')));
+  }
+  if ($memcache_debug_log = variable_get('memcache_debug_log', FALSE)) {
+    if (variable_get('memcache_debug_verbose', FALSE)) {
+      $verbose = t('verbose');
+    }
+    else {
+      $verbose = '';
+    }
+    drupal_set_message(t('You are writing !verbose debug logs to !debug_log.', array('!verbose' => $verbose, '!debug_log' => $memcache_debug_log)), 'warning');
+  }
+  $bin = memcache_admin_bin_mapping($bin);
+  $output = '';
+  $server = array();
+  $stats = dmemcache_stats($bin, 'default', TRUE);
+  if (empty($stats[$bin])) {
+    // Failed to load statistics. Provide a useful error about where to get
+    // more information and help.
+    drupal_set_message(t('Failed to retreive statistics. There may be a problem with your Memcache configuration. Please review %readme and !more for more information.', array('%readme' => 'README.txt', 'admin/reports/status', '!more' => module_exists('memcache') ? t('visit the Drupal admin !status page', array('!status' => l(t('status report'), 'admin/reports/status'))) : t('!enable the memcache module', array('!enable' => l(t('enable'), 'admin/modules', array('fragment' => 'edit-modules-performance-and-scalability')))))), 'error');
+  }
+  else {
+    $stats = $stats[$bin];
+    $aggregate = array_pop($stats);
+    $mc = dmemcache_object($bin);
+    if ($mc instanceof Memcached) {
+      $version = t('Memcached v!version', array('!version' => phpversion('Memcached')));
+    }
+    elseif ($mc instanceof Memcache) {
+      $version = t('Memcache v!version', array('!version' => phpversion('Memcache')));
+    }
+    else {
+      $version = t('Unknown');
+      drupal_set_message(t('Failed to detect the memcache PECL extension.'), 'error');
+    }
+    $memcache_servers = variable_get('memcache_servers', array('127.0.0.1:11211' => 'default'));
+
+    foreach ($stats as $server => $statistics) {
+      if (empty($statistics['uptime'])) {
+        drupal_set_message(t('Failed to connect to server at %address.', array('%address' => $server)), 'error');
+      }
+      else {
+        $servers[] = $server;
+        $data['server_overview'][$server] = t('v!version running !uptime', array('!version' => check_plain($statistics['version']), '!uptime' => format_interval($statistics['uptime'])));
+        $data['server_pecl'][$server] = t('n/a');
+        $data['server_serialize'][$server] = t('n/a');
+        $data['server_time'][$server] = format_date($statistics['time']);
+        $data['server_connections'][$server] = _memcache_admin_stats_connections($statistics);
+        $data['cache_sets'][$server] = _memcache_admin_stats_sets($statistics);
+        $data['cache_gets'][$server] = _memcache_admin_stats_gets($statistics);
+        $data['cache_counters'][$server] = _memcache_admin_stats_counters($statistics);
+        $data['cache_transfer'][$server] = _memcache_admin_stats_transfer($statistics);
+        $data['cache_average'][$server] = _memcache_admin_stats_average($statistics);
+        $data['memory_available'][$server] = _memcache_admin_stats_memory($statistics);
+        $data['memory_evictions'][$server] = number_format($statistics['evictions']);
+      }
+    }
+
+    // Don't display aggregate totals if there's only one server.
+    if (count($servers) == 1) {
+      $aggregate = array();
+    }
+
+    // Build a custom report array.
+    $report = array();
+
+    // Report server uptime.
+    $item = array(
+      'label' => t('Uptime'),
+      'servers' => $data['server_overview'],
+    );
+    if (count($aggregate)) {
+      $item['total'] = t('n/a');
+    }
+    $report['uptime'][] = $item;
+
+    // Report server PECL extension.
+    $item = array(
+      'label' => t('PECL extension'),
+    );
+    if (count($aggregate)) {
+      $item['servers'] = $data['server_pecl'];
+      $item['total'] = $version;
+    }
+    else {
+      $item['servers'] = array($servers[0] => $version);
+    }
+    $report['uptime'][] = $item;
+
+    // Report which serialize function is being used.
+    $item = array(
+      'label' => t('Serialize function')
+    );
+    $serialize_function = dmemcache_serialize();
+    if ($serialize_function != 'serialize') {
+      $serialize_function = t('!function v!version', array('!function' => $serialize_function, '!version' => phpversion(dmemcache_serialize_extension())));
+    }
+    if (count($aggregate)) {
+      $item['servers'] = $data['server_serialize'];
+      $item['total'] = $serialize_function;
+    }
+    else {
+      $item['servers'] = array($servers[0] => $serialize_function);
+    }
+    $report['uptime'][] = $item;
+
+    // Report server time.
+    $item = array(
+      'label' => t('Time'),
+      'servers' => $data['server_time'],
+    );
+    if (count($aggregate)) {
+      $item['total'] = t('n/a');
+    }
+    $report['uptime'][] = $item;
+
+    // Report number of connections.
+    $item = array(
+      'label' => t('Connections'),
+      'servers' => $data['server_connections'],
+    );
+    if (count($aggregate)) {
+      $item['total'] = _memcache_admin_stats_connections($aggregate);
+    }
+    $report['uptime'][] = $item;
+
+    $stats = array(
+      'sets' => t('Sets'),
+      'gets' => t('Gets'),
+      'counters' => t('Counters'),
+      'transfer' => t('Transferred'),
+      'average' => t('Per-connection average'),
+    );
+    foreach ($stats as $type => $label) {
+      $item = array(
+        'label' => $label,
+        'servers' => $data["cache_{$type}"],
+      );
+      if (count($aggregate)) {
+        $func = "_memcache_admin_stats_{$type}";
+        $item['total'] = $func($aggregate);
+      }
+      $report['stats'][] = $item;
+    }
+
+    // Report on available memory.
+    $item = array(
+      'label' => t('Available memory'),
+      'servers' => $data['memory_available'],
+    );
+    if (count($aggregate)) {
+      $item['total'] = _memcache_admin_stats_memory($aggregate);
+    }
+    $report['memory'][] = $item;
+
+    // Report on memory evictions.
+    $item = array(
+      'label' => t('Evictions'),
+      'servers' => $data['memory_evictions'],
+    );
+    if (count($aggregate)) {
+      $item['total'] = number_format($aggregate['evictions']);
+    }
+    $report['memory'][] = $item;
+    $output = theme('memcache_admin_stats_table', array(
+      'bin' => $bin,
+      'servers' => $servers,
+      'report' => $report,
+    ));
+  }
+  return $output;
+}
+
+/**
+ * Callback for the server statistics page.
+ */
+function memcache_admin_stats_raw($bin, $server, $type = 'default') {
+  $cluster = memcache_admin_bin_mapping($bin);
+  $slab = (int) arg(7);
+  if (arg(6) == 'cachedump' && !empty($slab) && user_access('access slab cachedump')) {
+    $stats = dmemcache_stats($cluster, arg(7), FALSE);
+  }
+  else {
+    $stats = dmemcache_stats($cluster, $type, FALSE);
+  }
+  $breadcrumbs = array(
+    l(t('Home'), NULL),
+    l(t('Administer'), 'admin'),
+    l(t('Reports'), 'admin/reports'),
+    l(t('Memcache'), 'admin/reports/memcache'),
+    l(t($bin), "admin/reports/memcache/$bin"),
+  );
+  if ($type == 'slabs' && arg(6) == 'cachedump' && user_access('access slab cachedump')) {
+    $breadcrumbs[] = l($server, "admin/reports/memcache/$bin/$server");
+    $breadcrumbs[] = l(t('slabs'), "admin/reports/memcache/$bin/$server/$type");
+  }
+  drupal_set_breadcrumb($breadcrumbs);
+  if (isset($stats[$cluster][$server]) && is_array($stats[$cluster][$server]) && count($stats[$cluster][$server])) {
+    $output = theme('memcache_admin_stats_raw_table', array(
+      'cluster' => $cluster,
+      'server' => $server,
+      'stats' => $stats[$cluster][$server],
+      'type' => $type,
+    ));
+  }
+  elseif ($type == 'slabs' && is_array($stats[$cluster]) && count($stats[$cluster])) {
+    $output = theme('memcache_admin_stats_raw_table', array(
+      'cluster' => $cluster,
+      'server' => $server,
+      'stats' => $stats[$cluster],
+      'type' => $type,
+    ));
+  }
+  else {
+    $output = theme('memcache_admin_stats_raw_table', array(
+      'cluster' => $cluster,
+      'server' => $server,
+      'stats' => array(),
+      'type' => $type,
+    ));
+    drupal_set_message(t('No @type statistics for this bin.', array('@type' => $type)));
+  }
+  return $output;
+}
+
+/**
+ * Implements hook_theme().
+ */
+function memcache_admin_theme() {
+  return array(
+    'memcache_admin_stats_table' => array(
+      'variables' => array(
+        'bin' => NULL,
+        'servers' => NULL,
+        'report' => NULL,
+      ),
+    ),
+    'memcache_admin_stats_raw_table' => array(
+      'variables' => array(
+        'bin' => NULL,
+        'server' => NULL,
+        'stats' => NULL,
+        'type' => NULL,
+      ),
+    ),
+  );
+}
+
+/**
+ * Theme function for rendering the output from memcache_admin_stats.
+ */
+function theme_memcache_admin_stats_table($variables) {
+  $bin = $variables['bin'];
+  $servers = $variables['servers'];
+  $stats = $variables['report'];
+
+  $output = '';
+
+  $links = array();
+  $memcache_bins = variable_get('memcache_bins', array('cache' => 'default'));
+  foreach ($servers as $server) {
+    $link_bin = $memcache_bins[$bin];
+    $links[] = l($server, check_plain("admin/reports/memcache/$link_bin/$server"));
+  }
+
+  if (count($servers) > 1) {
+    $headers = array_merge(array('', t('Totals')), $links);
+  }
+  else {
+    $headers = array_merge(array(''), $links);
+  }
+
+  foreach ($stats as $table => $data) {
+    $rows = array();
+    foreach ($data as $row) {
+      $r = array();
+      $r[] = $row['label'];
+      if (isset($row['total'])) {
+        $r[] = $row['total'];
+      }
+      foreach ($row['servers'] as $server) {
+        $r[] = $server;
+      }
+      $rows[] = $r;
+    }
+    $output .= theme('table', array('header' => $headers, 'rows' => $rows));
+  }
+  return $output;
+}
+
+/**
+ * Returns an array of available statistics types.
+ */
+function memcache_admin_stats_types($bin) {
+  module_load_include('inc', 'memcache', 'dmemcache');
+  if ($mc = dmemcache_object($bin)) {
+    if ($mc instanceof Memcache) {
+      // TODO: Determine which versions of the PECL memcache extension have
+      // these other stats types: 'malloc', 'maps', optionally detect this
+      // version and expose them.  These stats are "subject to change without
+      // warning" unfortunately.
+      return array('default', 'slabs', 'items', 'sizes');
+    }
+    else {
+      // The Memcached PECL extension only offers the default statistics.
+      return array('default');
+    }
+  }
+  else {
+    return array();
+  }
+}
+
+/**
+ * Theme function to produce a table of statistics.
+ */
+function theme_memcache_admin_stats_raw_table($variables) {
+  $cluster = $variables['cluster'];
+  $server = $variables['server'];
+  $stats = $variables['stats'];
+  $current_type = isset($variables['type']) ? $variables['type'] : 'default';
+
+  $memcache_bins = variable_get('memcache_bins', array());
+  $bin = isset($memcache_bins[$cluster]) ? $memcache_bins[$cluster] : 'default';
+  // Provide navigation for the various memcache stats types.
+  if (count(memcache_admin_stats_types($bin)) > 1) {
+    foreach (memcache_admin_stats_types($bin) as $type) {
+      if ($current_type == $type) {
+        $links[] = '<strong>' . l(t($type), "admin/reports/memcache/$bin/$server/" . ($type == 'default' ? '' : $type)) . '</strong>';
+      }
+      else {
+        $links[] = l(t($type), "admin/reports/memcache/$bin/$server/" . ($type == 'default' ? '' : $type));
+      }
+    }
+  }
+  $output = !empty($links) ? implode(' | ', $links) : '';
+
+  $headers = array(t('Property'), t('Value'));
+  $rows = array();
+  // Items are returned as an array within an array within an array.  We step
+  // in one level to properly display the contained statistics.
+  if ($current_type == 'items' && isset($stats['items'])) {
+    $stats = $stats['items'];
+  }
+  foreach ($stats as $key => $value) {
+    // Add navigation for getting a cachedump of individual slabs.
+    if (($current_type == 'slabs' || $current_type == 'items') && is_int($key) && user_access('access slab cachedump')) {
+      $key = l($key, "admin/reports/memcache/$bin/$server/slabs/cachedump/$key");
+    }
+    if (is_array($value)) {
+      $rs = array();
+      foreach ($value as $k => $v) {
+        // Format timestamp when viewing cachedump of individual slabs.
+        if ($current_type == 'slabs' && user_access('access slab cachedump') && arg(6) == 'cachedump' && $k == 0) {
+          $k = t('Size');
+          $v = format_size($v);
+        }
+        elseif ($current_type == 'slabs' && user_access('access slab cachedump') && arg(6) == 'cachedump' && $k == 1) {
+          $k = t('Expire');
+          $full_stats = dmemcache_stats($cluster, 'default');
+          $infinite = $full_stats[$cluster][$server]['time'] - $full_stats[$cluster][$server]['uptime'];
+          if ($v == $infinite) {
+            $v = t('infinite');
+          }
+          else {
+            $v = t('in @time', array('@time' => format_interval($v - time())));
+          }
+        }
+        $rs[] = array(check_plain($k), check_plain($v));
+      }
+      $rows[] = array($key, theme('table', array('rows' => $rs)));
+    }
+    else {
+      $rows[] = array(check_plain($key), check_plain($value));
+    }
+  }
+  $output .= theme('table', array('header' => $headers, 'rows' => $rows));
+  return $output;
+}
+
+/**
+ * Retrieve the bin for any given cluster.
+ *
+ * @param string $cluster
+ *   Cluster ID
+ *
+ * @return string
+ *   The name of the bin.
+ */
+function _memcache_admin_get_bin_for_cluster($cluster) {
+  static $cluster_map = array();
+
+  if (!isset($cluster_map[$cluster])) {
+    $memcache_bins = variable_get('memcache_bins', array());
+    if ($mapping = array_search($cluster, $memcache_bins)) {
+      $cluster_map[$cluster] = $mapping;
+    }
+    else {
+      $cluster_map[$cluster] = 'default';
+    }
+  }
+
+  return $cluster_map[$cluster];
+}
+
+/**
+ * Helper function. Calculate a percentage.
+ */
+function _memcache_admin_stats_percent($a, $b) {
+  if ($a == 0) {
+    return 0;
+  }
+  elseif ($b == 0) {
+    return 100;
+  }
+  else {
+    return $a / ($a + $b) * 100;
+  }
+}
+
+/**
+ * Displays memcache stats in the footer. This is run as a shutdown function.
+ *
+ * @see memcache_admin_init()
+ */
+function memcache_admin_shutdown() {
+  global $_dmemcache_stats;
+
+  // Don't call theme() during shutdown if the registry has been rebuilt (such
+  // as when enabling/disabling modules on admin/build/modules) as things break.
+  // Instead, simply exit without displaying admin statistics for this page
+  // load.  See http://drupal.org/node/616282 for discussion.
+  if (!function_exists('theme_get_registry') || !theme_get_registry()) {
+    return;
+  }
+
+  // Try not to break non-HTML pages.
+  if (function_exists('drupal_get_http_header')) {
+    $header = drupal_get_http_header('content-type');
+    if ($header) {
+      $formats = array(
+        'xml',
+        'javascript',
+        'json',
+        'plain',
+        'image',
+        'application',
+        'csv',
+        'x-comma-separated-values',
+      );
+      foreach ($formats as $format) {
+        if (strstr($header, $format)) {
+          return;
+        }
+      }
+    }
+    else {
+      // Workaround for CKEditor, see https://www.drupal.org/node/2556999
+      return;
+    }
+  }
+
+  if (variable_get('show_memcache_statistics', FALSE) && function_exists('user_access') && user_access('access memcache statistics')) {
+    $output = '';
+    if (!empty($_dmemcache_stats['ops'])) {
+      foreach ($_dmemcache_stats['ops'] as $row => $stats) {
+        $_dmemcache_stats['ops'][$row][0] = check_plain($stats[0]);
+        $_dmemcache_stats['ops'][$row][1] = number_format($stats[1], 2);
+        $hits = number_format(_memcache_admin_stats_percent($stats[2], $stats[3]), 1);
+        $misses = number_format(_memcache_admin_stats_percent($stats[3], $stats[2]), 1);
+        $_dmemcache_stats['ops'][$row][2] = number_format($stats[2]) . " ($hits%)";
+        $_dmemcache_stats['ops'][$row][3] = number_format($stats[3]) . " ($misses%)";
+      }
+      $variables = array(
+        'header' => array(
+          t('operation'),
+          t('total ms'),
+          t('total hits'),
+          t('total misses'),
+        ),
+        'rows' => $_dmemcache_stats['ops'],
+      );
+      $output .= theme('table', $variables);
+    }
+    if (!empty($_dmemcache_stats['all'])) {
+      foreach ($_dmemcache_stats['all'] as $row => $stats) {
+        $_dmemcache_stats['all'][$row][1] = check_plain($stats[1]);
+        $_dmemcache_stats['all'][$row][2] = check_plain($stats[2]);
+        $_dmemcache_stats['all'][$row][3] = check_plain($stats[3]);
+      }
+
+      $variables = array(
+        'header' => array(
+          t('ms'),
+          t('operation'),
+          t('bin'),
+          t('key'),
+          t('status'),
+        ),
+        'rows' => $_dmemcache_stats['all'],
+      );
+      $output .= theme('table', $variables);
+
+    }
+    if (!empty($output)) {
+      // This makes sure all of the HTML is within the <body> even though this
+      // <script> is outside it.
+      print '<div id="memcache-devel"><h2>' . t('Memcache statistics for @url', array('@url' => current_path())) . '</h2>' . $output . '</div>';
+    }
+  }
+}

--- a/html/sites/all/modules/contrib/memcache/tests/memcache-lock.test
+++ b/html/sites/all/modules/contrib/memcache/tests/memcache-lock.test
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @file
+ * Tests for the lock system.
+ */
+
+class MemcacheLockFunctionalTest extends MemcacheTestCase {
+  protected $default_bin = '';
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Locking framework tests',
+      'description' => 'Confirm locking works between two separate requests.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * @see MemcacheTestCase::setUp()
+   */
+  public function setUp() {
+    parent::setUp('memcache_test');
+  }
+
+  /**
+   * Confirm that we can acquire and release locks in two parallel requests.
+   */
+  public function testLockAcquire() {
+    // Confirm that locks are really acquired in memcache.
+    lock_acquire($this->default_cid);
+    $this->assertTrue(dmemcache_get($this->default_cid, 'semaphore'), t('Memcache locking is configured correctly.'));
+    lock_release($this->default_cid);
+
+    // Nasty hack. There are two processes involved here - the process
+    // calling the test itself, that calls lock_acquire() directly. And the
+    // 'child' process that is requested over http by drupalGet().
+    // In dmemcache.inc, we look for simpletest installs, to force a
+    // simpletest prefix as part of the memcache key - this avoids the
+    // actual Drupal site install being corrupted by entries from the tested
+    // site. However, the child install apparently does not set the simpletest
+    // global, so when making requests to that site, we pass the simpletest ID
+    // as part of the URL, and mess around with the globals on that side.
+    $test_run_id = $GLOBALS['drupal_test_info']['test_run_id'];
+    $lock_acquired = 'TRUE: Lock successfully acquired in memcache_test_lock_acquire()';
+    $lock_not_acquired = 'FALSE: Lock not acquired in memcache_test_lock_acquire()';
+    $this->assertTrue(lock_acquire('memcache_test_lock_acquire'), t('Lock acquired by this request.'), t('Lock'));
+    $this->assertTrue(lock_acquire('memcache_test_lock_acquire'), t('Lock extended by this request.'), t('Lock'));
+    lock_release('memcache_test_lock_acquire');
+
+    // Cause another request to acquire the lock.
+    $this->drupalGet('memcache-test/lock-acquire' . "/$test_run_id");
+    $this->assertText($lock_acquired, t('Lock acquired by the other request.'), t('Lock'));
+    // The other request has finished, thus it should have released its lock.
+    $this->assertTrue(lock_acquire('memcache_test_lock_acquire'), t('Lock acquired by this request.'), t('Lock'));
+    // This request holds the lock, so the other request cannot acquire it.
+    $this->drupalGet('memcache-test/lock-acquire' . "/$test_run_id");
+    $this->assertText($lock_not_acquired, t('Lock not acquired by the other request.'), t('Lock'));
+    lock_release('memcache_test_lock_acquire');
+
+    // Try a very short timeout and lock breaking.
+    $this->assertTrue(lock_acquire('memcache_test_lock_acquire', 1), t('Lock acquired by this request.'), t('Lock'));
+    sleep(2);
+    // The other request should break our lock.
+    $this->drupalGet('memcache-test/lock-acquire' . "/$test_run_id");
+    $this->assertText($lock_acquired, t('Lock acquired by the other request, breaking our lock.'), t('Lock'));
+    // We cannot renew it, since the other thread took it.
+    // @todo: this assertion currently fails - the lock_acquire() call returns
+    // true. For now, commented out the assertion, uncomment when attempting to
+    // fix.
+    // $this->assertFalse(lock_acquire('memcache_test_lock_acquire'), t('Lock cannot be extended by this request.'), t('Lock'));
+
+    // Check the shut-down function.
+    $lock_acquired_exit = 'TRUE: Lock successfully acquired in memcache_test_lock_exit()';
+    $lock_not_acquired_exit = 'FALSE: Lock not acquired in memcache_test_lock_exit()';
+    $this->drupalGet('memcache-test/lock-exit' . "/$test_run_id");
+    $this->assertText($lock_acquired_exit, t('Lock acquired by the other request before exit.'), t('Lock'));
+    $this->assertTrue(lock_acquire('memcache_test_lock_exit'), t('Lock acquired by this request after the other request exits.'), t('Lock'));
+  }
+
+}

--- a/html/sites/all/modules/contrib/memcache/tests/memcache.test
+++ b/html/sites/all/modules/contrib/memcache/tests/memcache.test
@@ -1,0 +1,1004 @@
+<?php
+
+/**
+ * @file
+ * Test cases for the memcache cache backend.
+ */
+
+class MemcacheTestCase extends DrupalWebTestCase {
+  protected $profile = 'testing';
+  protected $default_bin = 'cache_memcache';
+  protected $default_cid = 'test_temporary';
+  protected $default_value = 'MemcacheTest';
+
+  /**
+   * Re-implements DrupalWebTestCase::setUp() so that we can override $conf.
+   *
+   * @see DrupalWebTestCase::setUp()
+   */
+  public function setUp() {
+    global $user, $language, $conf;
+
+    // Create the database prefix for this test.
+    $this->prepareDatabasePrefix();
+
+    // Prepare the environment for running tests.
+    $this->prepareEnvironment();
+    if (!$this->setupEnvironment) {
+      return FALSE;
+    }
+
+    // Reset all statics and variables to perform tests in a clean environment.
+    $conf = array();
+    drupal_static_reset();
+
+    // Setup our own memcache variables here. We can't use variable_set() yet.
+    if ($this->default_bin) {
+      $conf["cache_flush_$this->default_bin"] = 0;
+      $conf["cache_class_$this->default_bin"] = 'MemcacheDrupal';
+    }
+
+    // Change the database prefix.
+    // All static variables need to be reset before the database prefix is
+    // changed, since DrupalCacheArray implementations attempt to
+    // write back to persistent caches when they are destructed.
+    $this->changeDatabasePrefix();
+    if (!$this->setupDatabasePrefix) {
+      return FALSE;
+    }
+
+    // Preset the 'install_profile' system variable, so the first call into
+    // system_rebuild_module_data() (in drupal_install_system()) will register
+    // the test's profile as a module. Without this, the installation profile of
+    // the parent site (executing the test) is registered, and the test
+    // profile's hook_install() and other hook implementations are never
+    // invoked.
+    $conf['install_profile'] = $this->profile;
+
+    // Perform the actual Drupal installation.
+    include_once DRUPAL_ROOT . '/includes/install.inc';
+    drupal_install_system();
+
+    $this->preloadRegistry();
+
+    // Set path variables.
+    variable_set('file_public_path', $this->public_files_directory);
+    variable_set('file_private_path', $this->private_files_directory);
+    variable_set('file_temporary_path', $this->temp_files_directory);
+
+    // Set the 'simpletest_parent_profile' variable to add the parent profile's
+    // search path to the child site's search paths.
+    // @see drupal_system_listing()
+    // @todo This may need to be primed like 'install_profile' above.
+    variable_set('simpletest_parent_profile', $this->originalProfile);
+
+    // Include the testing profile.
+    variable_set('install_profile', $this->profile);
+    $profile_details = install_profile_info($this->profile, 'en');
+
+    // Install the modules specified by the testing profile.
+    module_enable($profile_details['dependencies'], FALSE);
+
+    // Install modules needed for this test. This could have been passed in as
+    // either a single array argument or a variable number of string arguments.
+    // @todo Remove this compatibility layer in Drupal 8, and only accept
+    // $modules as a single array argument.
+    $modules = func_get_args();
+    if (isset($modules[0]) && is_array($modules[0])) {
+      $modules = $modules[0];
+    }
+    if ($modules) {
+      $success = module_enable($modules, TRUE);
+      $this->assertTrue($success, t('Enabled modules: %modules', array('%modules' => implode(', ', $modules))));
+    }
+
+    // Run the profile tasks.
+    $install_profile_module_exists = db_query("SELECT 1 FROM {system} WHERE type = 'module' AND name = :name", array(
+      ':name' => $this->profile,
+    ))->fetchField();
+    if ($install_profile_module_exists) {
+      module_enable(array($this->profile), FALSE);
+    }
+
+    // Reset/rebuild all data structures after enabling the modules.
+    $this->resetAll();
+
+    // Run cron once in that environment, as install.php does at the end of
+    // the installation process.
+    drupal_cron_run();
+
+    // Ensure that the session is not written to the new environment and replace
+    // the global $user session with uid 1 from the new test site.
+    drupal_save_session(FALSE);
+    // Login as uid 1.
+    $user = user_load(1);
+
+    // Restore necessary variables.
+    variable_set('install_task', 'done');
+    variable_set('clean_url', $this->originalCleanUrl);
+    variable_set('site_mail', 'simpletest@example.com');
+    variable_set('date_default_timezone', date_default_timezone_get());
+
+    // Set up English language.
+    unset($conf['language_default']);
+    $language = language_default();
+
+    // Use the test mail class instead of the default mail handler class.
+    variable_set('mail_system', array('default-system' => 'TestingMailSystem'));
+
+    drupal_set_time_limit($this->timeLimit);
+    $this->setup = TRUE;
+
+    if ($this->default_bin) {
+      // Save our memcache variables.
+      variable_set("cache_flush_$this->default_bin", 0);
+      variable_set("cache_class_$this->default_bin", 'MemcacheDrupal');
+    }
+
+    $this->resetVariables();
+  }
+
+  /**
+   * Test that memcache is configured correctly.
+   */
+  public function testCacheBin() {
+    if ($this->default_bin) {
+      // Confirm that the default cache bin is handled by memcache.
+      $this->assertEqual(get_class(_cache_get_object($this->default_bin)), 'MemCacheDrupal', t('Memcache caching is configured correctly.'));
+    }
+  }
+
+  /**
+   * Check whether or not a cache entry exists.
+   *
+   * @param string $cid
+   *   The cache id.
+   * @param mixed $var
+   *   The variable the cache should contain.
+   * @param string $bin
+   *   Defaults to $this->default_bin. The bin the cache item was stored in.
+   *
+   * @return bool
+   *   TRUE on pass, FALSE on fail.
+   */
+  protected function checkCacheExists($cid, $var, $bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+
+    $cache = cache_get($cid, $bin);
+
+    return isset($cache->data) && $cache->data == $var;
+  }
+
+  /**
+   * Assert or a cache entry exists.
+   *
+   * @param string $message
+   *   Message to display.
+   * @param mixed $var
+   *   Defaults to $this->default_value. The variable the cache should contain.
+   * @param string $cid
+   *   Defaults to $this->default_cid. The cache id.
+   * @param string $bin
+   *   Defaults to $this->default_bin. The bin the cache item was stored in.
+   */
+  protected function assertCacheExists($message, $var = NULL, $cid = NULL, $bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+    if ($cid == NULL) {
+      $cid = $this->default_cid;
+    }
+    if ($var == NULL) {
+      $var = $this->default_value;
+    }
+
+    $this->assertTrue($this->checkCacheExists($cid, $var, $bin), $message);
+  }
+
+  /**
+   * Assert or a cache entry has been removed.
+   *
+   * @param string $message
+   *   Message to display.
+   * @param string $cid
+   *   Defaults to $this->default_cid. The cache id.
+   * @param string $bin
+   *   Defaults to $this->default_bin. The bin the cache item was stored in.
+   */
+  public function assertCacheRemoved($message, $cid = NULL, $bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+    if ($cid == NULL) {
+      $cid = $this->default_cid;
+    }
+
+    $cache = cache_get($cid, $bin);
+    $this->assertFalse($cache, $message);
+  }
+
+  /**
+   * Perform the general wipe.
+   *
+   * @param string $bin
+   *   Defaults to $this->default_bin. The bin to perform the wipe on.
+   */
+  protected function generalWipe($bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+
+    cache_clear_all(NULL, $bin);
+  }
+
+  /**
+   * Reloads internal MemCacheDrupal variables.
+   */
+  protected function resetVariables() {
+    if ($this->default_bin) {
+      $_SESSION['cache_flush'][$this->default_bin] = 0;
+      $cache = _cache_get_object($this->default_bin);
+      if ($cache instanceof MemCacheDrupal) {
+        $cache->reloadVariables();
+      }
+    }
+  }
+}
+
+class MemCacheSavingCase extends MemcacheTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Memcache saving test',
+      'description' => 'Check our variables are saved and restored the right way.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * @see MemcacheTestCase::setUp()
+   */
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Test the saving and restoring of a string.
+   */
+  public function testString() {
+    $this->checkVariable($this->randomName(100));
+  }
+
+  /**
+   * Test the saving and restoring of an integer.
+   */
+  public function testInteger() {
+    $this->checkVariable(100);
+  }
+
+  /**
+   * Test the saving and restoring of a double.
+   */
+  public function testDouble() {
+    $this->checkVariable(1.29);
+  }
+
+  /**
+   * Test the saving and restoring of an array.
+   */
+  public function testArray() {
+    $this->checkVariable(array(
+      'drupal1',
+      'drupal2' => 'drupal3',
+      'drupal4' => array('drupal5', 'drupal6'),
+    ));
+  }
+
+  /**
+   * Test the saving and restoring of an object.
+   */
+  public function testObject() {
+    $test_object = new stdClass();
+    $test_object->test1 = $this->randomName(100);
+    $test_object->test2 = 100;
+    $test_object->test3 = array(
+      'drupal1',
+      'drupal2' => 'drupal3',
+      'drupal4' => array('drupal5', 'drupal6'),
+    );
+
+    cache_set('test_object', $test_object, $this->default_bin);
+    $cache = cache_get('test_object', $this->default_bin);
+    $this->assertTrue(isset($cache->data) && $cache->data == $test_object, t('Object is saved and restored properly.'));
+  }
+
+  /**
+   * Test save and restoring a string with a long key.
+   */
+  public function testStringLongKey() {
+    $this->checkVariable($this->randomName(100), 'ThequickbrownfoxjumpsoverthelazydogThequickbrownfoxjumpsoverthelazydogThequickbrownfoxjumpsoverthelazydogThequickbrownfoxjumpsoverthelazydogThequickbrownfoxjumpsoverthelazydogThequickbrownfoxjumpsoverthelazydogThequickbrownfoxjumpsoverthelazydogThequickbrownfoxjumpsoverthelazydog');
+  }
+
+  /**
+   * Test save and restoring a string using a key with special characters.
+   */
+  public function testStringSpecialKey() {
+    $this->checkVariable($this->randomName(100), 'Qwerty!@#$%^&*()_+-=[]\;\',./<>?:"{}|£¢');
+  }
+
+  /**
+   * Test saving and restoring an integer value directly with dmemcache_set().
+   */
+  function testIntegerValue() {
+    $key = $this->randomName(100);
+    $val = rand(1, 1000);
+    dmemcache_set($key, $val, 0, 'cache');
+    $cache = dmemcache_get($key, 'cache');
+    $this->assertTrue($val === $cache, t('Integer is saved and restored properly with key @key', array('@key' => $key)));
+  }
+
+  /**
+   * Test saving and restoring a very large value (>1MiB).
+   */
+  function testLargeValue() {
+    $this->checkVariable(array_fill(0, 500000, rand()));
+  }
+
+  /**
+   * Test save and restoring a string with a long key and a very large value.
+   */
+  function testLongKeyLargeValue() {
+    $this->checkVariable(array_fill(0, 500000, rand()), $this->randomName(300));
+  }
+
+  /**
+   * Check or a variable is stored and restored properly.
+   */
+  public function checkVariable($var, $key = 'test_var') {
+    cache_set($key, $var, $this->default_bin);
+    $cache = cache_get($key, $this->default_bin);
+    $this->assertTrue(isset($cache->data) && $cache->data === $var, t('@type is saved and restored properly!key.', array('@type' => ucfirst(gettype($var)), '!key' => ($key != 'test_var') ? t(' with key @key', array('@key' => $key)) : '')));
+  }
+}
+
+/**
+ * Test cache_get_multiple().
+ */
+class MemCacheGetMultipleUnitTest extends MemcacheTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Fetching multiple cache items',
+      'description' => 'Confirm that multiple records are fetched correctly.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * @see MemcacheTestCase::setUp()
+   */
+  function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Test cache_get_multiple().
+   */
+  public function testCacheMultiple() {
+    $item1 = $this->randomName(10);
+    $item2 = $this->randomName(10);
+    cache_set('test:item1', $item1, $this->default_bin);
+    cache_set('test:item2', $item2, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test:item1', $item1), t('Item 1 is cached.'));
+    $this->assertTrue($this->checkCacheExists('test:item2', $item2), t('Item 2 is cached.'));
+
+    // Fetch both records from the database with cache_get_multiple().
+    $item_ids = array('test:item1', 'test:item2');
+    $items = cache_get_multiple($item_ids, $this->default_bin);
+    $this->assertEqual($items['test:item1']->data, $item1, t('Item was returned from cache successfully.'));
+    $this->assertEqual($items['test:item2']->data, $item2, t('Item was returned from cache successfully.'));
+
+    $this->assertTrue(empty($item_ids), t('Ids of returned items have been removed.'));
+
+    // Remove one item from the cache.
+    cache_clear_all('test:item2', $this->default_bin);
+
+    // Confirm that only one item is returned by cache_get_multiple().
+    $item_ids = array('test:item1', 'test:item2');
+    $items = cache_get_multiple($item_ids, $this->default_bin);
+    $this->assertEqual($items['test:item1']->data, $item1, t('Item was returned from cache successfully.'));
+    $this->assertFalse(isset($items['test:item2']), t('Item was not returned from the cache.'));
+    $this->assertTrue(count($items) == 1, t('Only valid cache entries returned.'));
+    $this->assertTrue(count($item_ids) == 1, t('Invalid cache ids still present.'));
+
+  }
+}
+
+/**
+ * Test cache clearing methods.
+ */
+class MemCacheClearCase extends MemcacheTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Cache clear test',
+      'description' => 'Check our clearing is done the proper way.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * @see MemcacheTestCase::setUp()
+   */
+  public function setUp() {
+
+    parent::setUp('memcache_test');
+    $this->default_value = $this->randomName(10);
+  }
+
+
+  /**
+   * Test clearing the cache with a cid, no cache lifetime.
+   */
+  public function testClearCidNoLifetime() {
+    $this->clearCidTest();
+  }
+
+  /**
+   * Test clearing the cache with a cid, with cache lifetime.
+   */
+  public function testClearCidLifetime() {
+    variable_set('cache_lifetime', 6000);
+    $this->clearCidTest();
+  }
+
+  /**
+   * Test clearing using wildcard prefixes, no cache lifetime.
+   */
+  public function testClearWildcardNoLifetime() {
+    $this->clearWildcardPrefixTest();
+  }
+
+  /**
+   * Test clearing using wildcard prefix, with cache lifetime.
+   */
+  public function testClearWildcardLifetime() {
+    variable_set('cache_lifetime', 6000);
+    $this->clearWildcardPrefixTest();
+  }
+
+  /**
+   * Test full bin flushes with no cache lifetime.
+   */
+  public function testClearWildcardFull() {
+    cache_set('test_cid_clear1', $this->default_value, $this->default_bin);
+    cache_set('test_cid_clear2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches were created for checking cid "*" with wildcard true.'));
+    cache_clear_all('*', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      || $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches removed after clearing cid "*" with wildcard true.'));
+  }
+
+  /**
+   * Test full bin flushes with cache lifetime.
+   */
+  public function testClearCacheLifetime() {
+    variable_set('cache_lifetime', 600);
+    $this->resetVariables();
+
+    // Set a cache item with an expiry.
+    cache_set('test_cid', $this->default_value, $this->default_bin, time() + 3600);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was created successfully.');
+
+    // Set a permanent cache item.
+    cache_set('test_cid_2', $this->default_value, $this->default_bin);
+
+    // Clear the page and block caches.
+    cache_clear_all(MEMCACHE_CONTENT_CLEAR, $this->default_bin);
+    // Since the cache was cleared within the current session, cache_get()
+    // should return false.
+    $this->assertFalse($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was cleared successfully.');
+
+    // However permament items should stay in place.
+    $this->assertTrue($this->checkCacheExists('test_cid_2', $this->default_value), 'Cache item was not cleared');
+
+    // If $_SESSION['cache_flush'] is not set, then the expired item should
+    // be returned.
+    unset($_SESSION['cache_flush']);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item is still returned due to minimum cache lifetime.');
+
+    // Set a much shorter cache lifetime.
+    variable_set('cache_content_flush_' . $this->default_bin, 0);
+    variable_set('cache_lifetime', 1);
+    cache_set('test_cid', $this->default_value, $this->default_bin, time() + 6000);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was created successfully.');
+    cache_clear_all(MEMCACHE_CONTENT_CLEAR, $this->default_bin);
+    $this->assertFalse($this->checkCacheExists('test_cid', $this->default_value), 'Cache item is not returned once minimum cache lifetime has expired.');
+
+    // Reset the cache clear variables.
+    variable_set('cache_content_flush_' . $this->default_bin, 0);
+    variable_set('cache_lifetime', 6000);
+    $this->resetVariables();
+
+    // Confirm that cache_lifetime does not take effect for full bin flushes.
+    cache_set('test_cid', $this->default_value, $this->default_bin, time() + 6000);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was created successfully.');
+    cache_set('test_cid_2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_2', $this->default_value), 'Cache item was created successfully.');
+
+    // Now flush the bin.
+    cache_clear_all('*', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was cleared successfully.');
+    $this->assertFalse($this->checkCacheExists('test_cid_2', $this->default_value), 'Cache item was cleared successfully.');
+  }
+
+  /**
+   * Test different wildcards to verify the wildcard optimizations.
+   */
+  public function testWildCardOptimizations() {
+
+    // Set and clear a cache with a short cid/wildcard.
+    cache_set('foo:1', $this->default_value, $this->default_bin);
+
+    $this->assertCacheExists(t('Foo cache was set.'), $this->default_value, 'foo:1');
+
+    cache_clear_all('foo', $this->default_bin, TRUE);
+    $this->assertCacheRemoved(t('Foo cache was invalidated.'), 'foo:1');
+
+    // Set additional longer caches.
+    cache_set('foobar', $this->default_value, $this->default_bin);
+    cache_set('foofoo', $this->default_value, $this->default_bin);
+
+    $this->assertCacheExists(t('Foobar cache set.'), $this->default_value, 'foobar');
+    $this->assertCacheExists(t('Foofoo cache set.'), $this->default_value, 'foofoo');
+
+    // Clear one of them with a wildcard and make sure the other one is still
+    // valid.
+    cache_clear_all('foobar', $this->default_bin, TRUE);
+    $this->assertCacheRemoved(t('Foobar cache invalidated.'), 'foobar');
+    $this->assertCacheExists(t('Foofoo cache still valid.'), $this->default_value, 'foofoo');
+
+    // Set and clear a cache with a different, equally short cid/wildcard.
+    cache_set('bar:1', $this->default_value, $this->default_bin);
+    $this->assertCacheExists(t('Bar cache was set.'), $this->default_value, 'bar:1');
+
+    cache_clear_all('bar', $this->default_bin, TRUE);
+    $this->assertCacheRemoved(t('Bar cache invalidated.'), 'bar:1');
+    $this->assertCacheExists(t('Foofoo cache still valid.'), $this->default_value, 'foofoo');
+
+    // Clear cache with an even shorter wildcard. This results in a full bin
+    // bin clear, all entries are marked invalid.
+    cache_set('bar:2', $this->default_value, $this->default_bin);
+    cache_clear_all('ba', $this->default_bin, TRUE);
+    $this->assertCacheRemoved(t('Bar:1 cache invalidated.'), 'bar:1');
+    $this->assertCacheRemoved(t('Bar:2 cache invalidated.'), 'bar:2');
+    $this->assertCacheRemoved(t('Foofoo cache invalidated.'), 'foofoo');
+  }
+
+  /**
+   * Test CACHE_TEMPORARY and CACHE_PERMANENT behaviour.
+   */
+  public function testClearTemporaryPermanent() {
+    cache_set('test_cid_clear_temporary', $this->default_value, $this->default_bin, CACHE_TEMPORARY);
+    cache_set('test_cid_clear_permanent', $this->default_value, $this->default_bin, CACHE_PERMANENT);
+    cache_set('test_cid_clear_future', $this->default_value, $this->default_bin, time() + 3600);
+
+    $this->assertTrue($this->checkCacheExists('test_cid_clear_temporary', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear_permanent', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear_future', $this->default_value),
+                      t('Three cache items were created for checking cache expiry.'));
+
+    // This should clear only expirable items (CACHE_TEMPORARY).
+    cache_clear_all(NULL, $this->default_bin, TRUE);
+
+    $this->assertFalse($this->checkCacheExists('test_cid_clear_temporary', $this->default_value),
+                      t('Temporary cache item was removed after clearing cid NULL.'));
+    $this->assertTrue($this->checkCacheExists('test_cid_clear_permanent', $this->default_value),
+                      t('Permanent cache item was not removed after clearing cid NULL.'));
+    $this->assertTrue($this->checkCacheExists('test_cid_clear_future', $this->default_value),
+                      t('Future cache item was not removed after clearing cid NULL.'));
+  }
+
+
+  /**
+   * Test clearing using a cid.
+   */
+  public function clearCidTest() {
+    cache_set('test_cid_clear', $this->default_value, $this->default_bin);
+
+    $this->assertCacheExists(t('Cache was set for clearing cid.'), $this->default_value, 'test_cid_clear');
+    cache_clear_all('test_cid_clear', $this->default_bin);
+
+    $this->assertCacheRemoved(t('Cache was removed after clearing cid.'), 'test_cid_clear');
+
+    cache_set('test_cid_clear1', $this->default_value, $this->default_bin);
+    cache_set('test_cid_clear2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches were created for checking cid "*" with wildcard false.'));
+    cache_clear_all('*', $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches still exists after clearing cid "*" with wildcard false.'));
+  }
+
+  /**
+   * Test cache clears using wildcard prefixes.
+   */
+  public function clearWildcardPrefixTest() {
+    $this->resetVariables();
+    cache_set('test_cid_clear:1', $this->default_value, $this->default_bin);
+    cache_set('test_cid_clear:2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear:1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear:2', $this->default_value),
+                      t('Two caches were created for checking cid substring with wildcard true.'));
+    cache_clear_all('test_cid_clear:', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear:1', $this->default_value)
+                      || $this->checkCacheExists('test_cid_clear:2', $this->default_value),
+                      t('Two caches removed after clearing cid substring with wildcard true.'));
+    // Test for the case where a wildcard object disappears, for example a
+    // partial memcache restart or eviction.
+    cache_set('test_cid_clear:1', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear:1', $this->default_value), 'The cache was created successfully.');
+    cache_clear_all('test_', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear:1', $this->default_value), 'The cache was cleared successfully.');
+    // Delete the wildcard manually to simulate an eviction.
+    $wildcard = '.wildcard-test_cid_clear:';
+    dmemcache_delete($wildcard, $this->default_bin);
+    // Reset the memcache_wildcards() static cache.
+    // @todo: this is a class object in D7.
+    // memcache_wildcards(FALSE, FALSE, FALSE, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear:1', $this->default_value), 'The cache was cleared successfully.');
+  }
+
+  /**
+   * Test wildcard flushing on separate pages to ensure no static cache is used.
+   */
+  public function testClearWildcardOnSeparatePages() {
+
+    $random_wildcard = $this->randomName(2) . ':' . $this->randomName(3);
+    $random_key = $random_wildcard . ':' . $this->randomName(4) . ':' . $this->randomName(2);
+    $random_value = $this->randomName();
+
+    $this->drupalGetAJAX('memcache-test/clear-cache');
+
+    $data = $this->drupalGetAJAX('memcache-test/set/' . $random_key . '/' . $random_value);
+
+    $this->assertTrue(is_array($data), 'Cache has data.');
+    $this->assertEqual($random_key, $data['cid'], 'Cache keys match.');
+    $this->assertEqual($random_value, $data['data'], 'Cache values match.');
+
+    $data = $this->drupalGetAJAX('memcache-test/get/' . $random_key);
+    $this->assertEqual($random_key, $data['cid'], 'Cache keys match.');
+    $this->assertEqual($random_value, $data['data'], 'Cache values match.');
+
+    $this->drupalGet('memcache-test/clear/' . $random_key);
+
+    $data = $this->drupalGetAJAX('memcache-test/get/' . $random_key);
+    $this->assertFalse($data, 'Cache value at specific key was properly flushed.');
+
+    $data = $this->drupalGetAJAX('memcache-test/set/' . $random_key . '/' . $random_value);
+
+    $this->assertTrue(is_array($data), 'Cache has data.');
+    $this->assertEqual($random_key, $data['cid'], 'Cache keys match.');
+    $this->assertEqual($random_value, $data['data'], 'Cache values match.');
+
+    $data = $this->drupalGetAJAX('memcache-test/get/' . $random_key);
+    $this->assertEqual($random_key, $data['cid'], 'Cache keys match.');
+    $this->assertEqual($random_value, $data['data'], 'Cache values match.');
+
+    $this->drupalGet('memcache-test/wildcard-clear/' . $random_wildcard);
+
+    $data = $this->drupalGetAJAX('memcache-test/get/' . $random_key);
+    $this->assertFalse($data, 'Cache was properly flushed.');
+  }
+
+}
+
+/**
+ * Tests memcache stampede protection.
+ */
+class MemCacheStampedeProtection extends MemcacheTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Memcache stampede protection',
+      'description' => 'Tests memcache stampede protection.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * Tests the opt out functionality of stampede protection using a unit test.
+   */
+  public function testStampedeProtectionIgnoringUnit() {
+    global $conf;
+
+    // Setup a new test bin, to be able to override the used class.
+    $conf['cache_flush_test_bin'] = 0;
+    $conf['cache_class_test_bin'] = 'MockMemCacheDrupal';
+
+    $conf['cache_flush_test_bin_2'] = 0;
+    $conf['cache_class_test_bin_2'] = 'MockMemCacheDrupal';
+
+    // Setup stampede protection.
+    $conf['memcache_stampede_protection'] = TRUE;
+    $conf['memcache_stampede_protection_ignore'] = array(
+      'test_bin',
+      'test_bin_2' => array(
+        'cid_no_prefix',
+        'cid_with_prefix:*',
+      ),
+    );
+
+    // Ensure the mock object is used.
+    /** @var \MockMemCacheDrupal $cache_object_bin */
+    $cache_object_bin = _cache_get_object('test_bin');
+    $this->assertEqual(get_class($cache_object_bin), 'MockMemCacheDrupal');
+    /** @var \MockMemCacheDrupal $cache_object_bin2 */
+    $cache_object_bin2 = _cache_get_object('test_bin_2');
+    $this->assertEqual(get_class($cache_object_bin2), 'MockMemCacheDrupal');
+
+    // Test ignoring of an entire bin.
+    $this->assertFalse($cache_object_bin->stampedeProtected('test_cid'), t('Disable stampede protection for cid contained in a disabled bin.'));
+    $this->assertFalse($cache_object_bin->stampedeProtected('cid_no_prefix'), t('Disable stampede protection for cid without prefix in a disabled bin.'));
+    $this->assertFalse($cache_object_bin->stampedeProtected('cid_with_prefix:example'), t('Disable stampede protection for cid with prefix in a disabled bin.'));
+
+    // Test ignoring of specific CIDs.
+    $this->assertTrue($cache_object_bin2->stampedeProtected('test_cid'), t('Don\'t disable stampede protection for a specific non-matching cid.'));
+    $this->assertFalse($cache_object_bin2->stampedeProtected('cid_no_prefix'), t('Disable stampede protection for a specific cid.'));
+    $this->assertFalse($cache_object_bin2->stampedeProtected('cid_with_prefix:example'), t('Disable stampede protection for a specific cid with disabled prefix.'));
+    $this->assertTrue($cache_object_bin2->stampedeProtected('cid_with_other_prefix:example'), t('Don\'t disable stampede protection for a specific cid with a different prefix.'));
+  }
+
+}
+
+include_once dirname(__DIR__) . '/memcache.inc';
+
+/**
+ * Wraps the MemCacheDrupal class in order to be able to call a protected method.
+ */
+class MockMemCacheDrupal extends MemCacheDrupal {
+
+  public function stampedeProtected($cid) {
+    return parent::stampedeProtected($cid);
+  }
+
+}
+
+/**
+ * Test some real world cache scenarios with default modules.
+ *
+ * Please make sure you've set the proper memcache settings in the settings.php.
+ * Looks like I've not chance to change the cache settings to what's needed by
+ * this test.
+ */
+class MemCacheRealWorldCase extends MemcacheTestCase {
+  protected $profile = 'standard';
+  protected $default_bin = 'cache_menu';
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Real world cache tests',
+      'description' => 'Test some real world cache scenarios.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * @see MemcacheTestCase::setUp()
+   */
+  public function setUp() {
+    parent::setUp('menu');
+  }
+
+  /**
+   * Test if the menu module caching acts as expected.
+   *
+   * The menu module clears the affected menu if an menu item is changed using
+   * wildcards.
+   */
+  public function testMenu() {
+    // Create and login user.
+    $account = $this->drupalCreateUser(array(
+      'access administration pages',
+      'administer blocks',
+      'administer menu',
+      'create article content',
+    ));
+    $this->drupalLogin($account);
+
+    // Add Menu Link to test with.
+    $item = $this->addMenuLink();
+    $original_title = $item['link_title'];
+
+    // Check if menu link is displayed.
+    $this->drupalGet('');
+    $this->assertText($original_title, 'Menu item displayed in frontend');
+
+    // Change menu item multiple times and check if the change is reflected.
+    for ($i = 0; $i < 3; $i++) {
+      // Edit menu link.
+      $edit = array();
+      $edit['link_title'] = $this->randomName(16);;
+      $this->drupalPost("admin/structure/menu/item/{$item['mlid']}/edit", $edit, t('Save'));
+      if (!$this->assertResponse(200)) {
+        // One fail is enough.
+        break;
+      }
+      // Verify edited menu link.
+      if (!$this->drupalGet('admin/structure/menu/manage/' . $item['menu_name'])) {
+        // One fail is enough.
+        break;
+      }
+      $this->assertText($edit['link_title'], 'Menu link was edited');
+      $this->drupalGet('');
+      if (!$this->assertText($edit['link_title'], 'Change is reflected in frontend')) {
+        // One fail is enough.
+        break;
+      }
+    }
+  }
+
+  /**
+   * Adds a menu link.
+   *
+   * @see MenuTestCase::addMenuLink()
+   */
+  public function addMenuLink($plid = 0, $link = '<front>', $menu_name = 'main-menu') {
+    // View add menu link page.
+    $this->drupalGet("admin/structure/menu/manage/$menu_name/add");
+    $this->assertResponse(200);
+
+    $title = '!OriginalLink_' . $this->randomName(16);
+    $edit = array(
+      'link_path' => $link,
+      'link_title' => $title,
+      'description' => '',
+      // Use this to disable the menu and test.
+      'enabled' => TRUE,
+      // Setting this to true should test whether it works when we do the
+      // std_user tests.
+      'expanded' => TRUE,
+      'parent' => $menu_name . ':' . $plid,
+      'weight' => '0',
+    );
+
+    // Add menu link.
+    $this->drupalPost(NULL, $edit, t('Save'));
+    $this->assertResponse(200);
+    // Unlike most other modules, there is no confirmation message displayed.
+    $this->assertText($title, 'Menu link was added');
+
+    $item = db_query('SELECT * FROM {menu_links} WHERE link_title = :title', array(':title' => $title))->fetchAssoc();
+    return $item;
+  }
+}
+
+/**
+ * Test statistics generation.
+ */
+class MemCacheStatisticsTestCase extends MemcacheTestCase {
+
+  public static function getInfo() {
+    return array(
+      'name' => 'Statistics tests',
+      'description' => 'Test that statistics are being recorded appropriately.',
+      'group' => 'Memcache',
+    );
+  }
+
+  /**
+   * @see MemcacheTestCase::setUp()
+   */
+  public function setUp() {
+    parent::setUp('memcache_admin');
+
+    $conf['cache_default_class'] = 'MemCacheDrupal';
+    $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+  }
+
+  /**
+   * Checks for early bootstrap statistics.
+   *
+   * Tests that bootstrap cache commands are recorded when statistics are
+   * enabled and tests that statistics are not recorded when the user doesn't
+   * have access or displaying statistics is disabled.
+   */
+  public function testBootstrapStatistics() {
+    global $_dmemcache_stats;
+    // Expected statistics for cache_set() and cache_get().
+    $test_full_key = dmemcache_key($this->default_cid, $this->default_bin);
+
+    // List of bootstrap cids to check for.
+    $cache_bootstrap_cids = array(
+      'variables',
+      'bootstrap_modules',
+      'lookup_cache',
+      'system_list',
+      'module_implements'
+    );
+
+    // Turn on memcache statistics.
+    variable_set('show_memcache_statistics', TRUE);
+    drupal_static_reset('dmemcache_stats_init');
+
+    $this->drupalGet('<front>');
+    // Check that statistics are not displayed for anonymous users.
+    $this->assertNoRaw('<div id="memcache-devel">', 'Statistics not present.');
+
+    // Create and login a user without access to view statistics.
+    $account = $this->drupalCreateUser();
+    $this->drupalLogin($account);
+
+    // Check that statistics are not displayed for authenticated users without
+    // permission.
+    $this->assertNoRaw('<div id="memcache-devel">', 'Statistics not present.');
+
+    // Create and login a user with access to view statistics.
+    $account = $this->drupalCreateUser(array('access memcache statistics'));
+    $this->drupalLogin($account);
+
+    $this->drupalGet('<front>');
+    // Check that bootstrap statistics are visible.
+    foreach ($cache_bootstrap_cids as $stat) {
+      $key = $GLOBALS['drupal_test_info']['test_run_id'] . 'cache_bootstrap-' . $stat;
+      $this->assertRaw("<td>get</td><td>cache_bootstrap</td><td>{$key}</td>", t('Key @key found.', array('@key' => $key)));
+    }
+
+    // Clear boostrap cache items.
+    foreach ($cache_bootstrap_cids as $stat) {
+      _cache_get_object('cache_bootstrap')->clear($stat);
+    }
+
+    $this->drupalGet('<front>');
+    // Check that early bootstrap statistics are still visible and are being
+    // set too, after they were removed.
+    foreach ($cache_bootstrap_cids as $stat) {
+      $key = $GLOBALS['drupal_test_info']['test_run_id'] . 'cache_bootstrap-' . $stat;
+      $this->assertRaw("<td>get</td><td>cache_bootstrap</td><td>{$key}</td>", t('Key @key found (get).', array('@key' => $key)));
+      $this->assertRaw("<td>set</td><td>cache_bootstrap</td><td>{$key}</td>", t('Key @key found (set).', array('@key' => $key)));
+    }
+
+    // Clear the internal statistics store.
+    $_dmemcache_stats = array('all' => array(), 'ops' => array());
+    // Check that cache_set() statistics are being recorded.
+    cache_set($this->default_cid, $this->default_value, $this->default_bin);
+    $this->assertEqual($_dmemcache_stats['all'][0][1], 'set', 'Set action recorded.');
+    $this->assertEqual($_dmemcache_stats['all'][0][4], 'hit', 'Set action successful.');
+    $this->assertNotNull($_dmemcache_stats['ops']['set']);
+
+    // Clear the internal statistics store.
+    $_dmemcache_stats = array('all' => array(), 'ops' => array());
+    // Check that cache_get() statistics are being recorded.
+    cache_get($this->default_cid, $this->default_bin);
+    $this->assertEqual($_dmemcache_stats['all'][0][1], 'get', 'Get action recorded.');
+    $this->assertEqual($_dmemcache_stats['all'][0][4], 'hit', 'Get action successful.');
+    $this->assertNotNull($_dmemcache_stats['ops']['get']);
+
+    // Turn off memcache statistics.
+    variable_set('show_memcache_statistics', FALSE);
+    drupal_static_reset('dmemcache_stats_init');
+
+    $this->drupalGet('<front>');
+    // Check that statistics are not recorded when the user has access, but
+    // statistics are disabled.
+    $this->assertNoRaw('<div id="memcache-devel">', 'Statistics not present.');
+
+    // Clear the internal statistics store.
+    $_dmemcache_stats = array('all' => array(), 'ops' => array());
+    // Confirm that statistics are not recorded for get()'s when disabled.
+    cache_set($this->default_cid, $this->default_value, $this->default_bin);
+    $this->assertEqual($_dmemcache_stats, array('all' => array(), 'ops' => array()));
+
+    // Clear the internal statistics store.
+    $_dmemcache_stats = array('all' => array(), 'ops' => array());
+    // Confirm that statistics are not recorded for set()'s when disabled.
+    cache_get($this->default_cid, $this->default_bin);
+    $this->assertEqual($_dmemcache_stats, array('all' => array(), 'ops' => array()));
+  }
+}

--- a/html/sites/all/modules/contrib/memcache/tests/memcache6.test
+++ b/html/sites/all/modules/contrib/memcache/tests/memcache6.test
@@ -1,0 +1,343 @@
+<?php
+
+class MemcacheTestCase extends DrupalWebTestCase {
+  protected $default_bin = 'cache';
+  protected $default_cid = 'test_temporary';
+  protected $default_value = 'MemcacheTest';
+
+  function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Check whether or not a cache entry exists.
+   *
+   * @param $cid
+   *   The cache id.
+   * @param $var
+   *   The variable the cache should contain.
+   * @param $bin
+   *   The bin the cache item was stored in.
+   * @return
+   *   TRUE on pass, FALSE on fail.
+   */
+  protected function checkCacheExists($cid, $var, $bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+
+    $cache = cache_get($cid, $bin);
+
+    return isset($cache->data) && $cache->data == $var;
+  }
+
+  /**
+   * Assert or a cache entry exists.
+   *
+   * @param $message
+   *   Message to display.
+   * @param $var
+   *   The variable the cache should contain.
+   * @param $cid
+   *   The cache id.
+   * @param $bin
+   *   The bin the cache item was stored in.
+   */
+  protected function assertCacheExists($message, $var = NULL, $cid = NULL, $bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+    if ($cid == NULL) {
+      $cid = $this->default_cid;
+    }
+    if ($var == NULL) {
+      $var = $this->default_value;
+    }
+
+    $this->assertTrue($this->checkCacheExists($cid, $var, $bin), $message);
+  }
+
+  /**
+   * Assert or a cache entry has been removed.
+   *
+   * @param $message
+   *   Message to display.
+   * @param $cid
+   *   The cache id.
+   * @param $bin
+   *   The bin the cache item was stored in.
+   */
+  function assertCacheRemoved($message, $cid = NULL, $bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+    if ($cid == NULL) {
+      $cid = $this->default_cid;
+    }
+
+    $cache = cache_get($cid, $bin);
+    $this->assertFalse($cache, $message);
+  }
+
+  /**
+   * Perform the general wipe.
+   * @param $bin
+   *   The bin to perform the wipe on.
+   */
+  protected function generalWipe($bin = NULL) {
+    if ($bin == NULL) {
+      $bin = $this->default_bin;
+    }
+
+    cache_clear_all(NULL, $bin);
+  }
+
+  /**
+   * Setup the lifetime settings for caching.
+   *
+   * @param $time
+   *   The time in seconds the cache should minimal live.
+   */
+  protected function setupLifetime($time) {
+    variable_set('cache_lifetime', $time);
+    variable_set('cache_flush', 0);
+  }
+}
+
+class MemCacheSavingCase extends MemcacheTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Memcache saving test',
+      'description' => 'Check our variables are saved and restored the right way.',
+      'group' => 'Memcache'
+    );
+  }
+
+  function setUp() {
+    parent::setUp();
+    variable_set("cache_flush_cache", 0);
+  }
+
+  /**
+   * Test the saving and restoring of a string.
+   */
+  function testString() {
+    $this->checkVariable($this->randomName(100));
+  }
+
+  /**
+   * Test the saving and restoring of an integer.
+   */
+  function testInteger() {
+    $this->checkVariable(100);
+  }
+
+  /**
+   * Test the saving and restoring of a double.
+   */
+  function testDouble() {
+    $this->checkVariable(1.29);
+  }
+
+  /**
+   * Test the saving and restoring of an array.
+   */
+  function testArray() {
+    $this->checkVariable(array('drupal1', 'drupal2' => 'drupal3', 'drupal4' => array('drupal5', 'drupal6')));
+  }
+
+  /**
+   * Test the saving and restoring of an object.
+   */
+  function testObject() {
+    $test_object = new stdClass();
+    $test_object->test1 = $this->randomName(100);
+    $test_object->test2 = 100;
+    $test_object->test3 = array('drupal1', 'drupal2' => 'drupal3', 'drupal4' => array('drupal5', 'drupal6'));
+
+    cache_set('test_object', $test_object, 'cache');
+    $cache = cache_get('test_object', 'cache');
+    $this->assertTrue(isset($cache->data) && $cache->data == $test_object, t('Object is saved and restored properly.'));
+  }
+
+  /*
+   * Check or a variable is stored and restored properly.
+   **/
+  function checkVariable($var) {
+    cache_set('test_var', $var, 'cache');
+    $cache = cache_get('test_var', 'cache');
+    $this->assertTrue(isset($cache->data) && $cache->data === $var, t('@type is saved and restored properly.', array('@type' => ucfirst(gettype($var)))));
+  }
+}
+
+/**
+ * Test cache clearing methods.
+ */
+class MemCacheClearCase extends MemcacheTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Cache clear test',
+      'description' => 'Check our clearing is done the proper way.',
+      'group' => 'Memcache'
+    );
+  }
+
+  function setUp() {
+    $this->default_bin = 'cache_page';
+    $this->default_value = $this->randomName(10);
+
+    parent::setUp();
+  }
+
+
+  /**
+   * Test clearing the cache with a cid, no cache lifetime.
+   */
+  function testClearCidNoLifetime() {
+    $this->clearCidTest();
+  }
+
+  /**
+   * Test clearing the cache with a cid, with cache lifetime.
+   */
+  function testClearCidLifetime() {
+    variable_set('cache_lifetime', 6000);
+    $this->clearCidTest();
+  }
+
+  /**
+   * Test clearing using wildcard prefixes, no cache lifetime.
+   */
+  function testClearWildcardNoLifetime() {
+    $this->clearWildcardPrefixTest();
+  }
+
+  /**
+   * Test clearing using wildcard prefix, with cache lifetime.
+   */
+  function testClearWildcardLifetime() {
+    variable_set('cache_lifetime', 6000);
+    $this->clearWildcardPrefixTest();
+  }
+
+  /**
+   * Test full bin flushes with no cache lifetime.
+   */
+  function testClearWildcardFull() {
+    variable_set("cache_flush_$this->default_bin", 0);
+    cache_set('test_cid_clear1', $this->default_value, $this->default_bin);
+    cache_set('test_cid_clear2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches were created for checking cid "*" with wildcard true.'));
+    cache_clear_all('*', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      || $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches removed after clearing cid "*" with wildcard true.'));
+  }
+
+  /**
+   * Test full bin flushes with cache lifetime.
+   */
+  function testClearCacheLifetime() {
+    variable_set("cache_flush_$this->default_bin", 0);
+    variable_set('cache_lifetime', 600);
+
+    // Set a cache item with an expiry.
+    cache_set('test_cid', $this->default_value, $this->default_bin, time() + 3600);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was created successfully.');
+
+    // Set a permanent cache item.
+    cache_set('test_cid_2', $this->default_value, $this->default_bin);
+
+    // Clear the page and block caches.
+    cache_clear_all();
+    // Since the cache was cleared within the current session, cache_get()
+    // should return false.
+    $this->assertFalse($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was cleared successfully.');
+
+    // However permament items should stay in place.
+    $this->assertTrue($this->checkCacheExists('test_cid_2', $this->default_value), 'Cache item was not cleared');
+
+    // If $_SESSION['cache_flush'] is not set, then the expired item should be returned.
+    unset($_SESSION['cache_flush']);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item is still returned due to minimum cache lifetime.');
+
+    // Set a much shorter cache lifetime.
+    variable_set('cache_content_flush_' . $this->default_bin, 0);
+    variable_set('cache_lifetime', 1);
+    cache_set('test_cid_1', $this->default_value, $this->default_bin, time() + 6000);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was created successfully.');
+    sleep(2);
+    cache_clear_all();
+    $this->assertFalse($this->checkCacheExists('test_cid', $this->default_value), 'Cache item is not returned once minimum cache lifetime has expired.');
+
+    // Reset the cache clear variables.
+    variable_set('cache_content_flush_' . $this->default_bin, 0);
+    variable_set('cache_lifetime', 6000);
+    sleep(1);
+
+    // Confirm that cache_lifetime does not take effect for full bin flushes.
+    cache_set('test_cid', $this->default_value, $this->default_bin, time() + 6000);
+    $this->assertTrue($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was created successfully.');
+    cache_set('test_cid_2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_2', $this->default_value), 'Cache item was created successfully.');
+
+    // Now flush the bin.
+    cache_clear_all('*', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid', $this->default_value), 'Cache item was cleared successfully.');
+    $this->assertFalse($this->checkCacheExists('test_cid_2', $this->default_value), 'Cache item was cleared successfully.');
+  }
+
+
+  /**
+   * Test clearing using a cid.
+   */
+  function clearCidTest() {
+    variable_set("cache_flush_$this->default_bin", 0);
+    cache_set('test_cid_clear', $this->default_value, $this->default_bin);
+
+    $this->assertCacheExists(t('Cache was set for clearing cid.'), $this->default_value, 'test_cid_clear');
+    cache_clear_all('test_cid_clear', $this->default_bin);
+
+    $this->assertCacheRemoved(t('Cache was removed after clearing cid.'), 'test_cid_clear');
+
+    cache_set('test_cid_clear1', $this->default_value, $this->default_bin);
+    cache_set('test_cid_clear2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches were created for checking cid "*" with wildcard false.'));
+    cache_clear_all('*', $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches still exists after clearing cid "*" with wildcard false.'));
+  }
+
+  /**
+   * Test cache clears using wildcard prefixes.
+   */
+  function clearWildcardPrefixTest() {
+    variable_set("cache_flush_$this->default_bin", 0);
+    cache_set('test_cid_clear1', $this->default_value, $this->default_bin);
+    cache_set('test_cid_clear2', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      && $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches were created for checking cid substring with wildcard true.'));
+    cache_clear_all('test_', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear1', $this->default_value)
+                      || $this->checkCacheExists('test_cid_clear2', $this->default_value),
+                      t('Two caches removed after clearing cid substring with wildcard true.'));
+    // Test for the case where a wildcard object disappears, for example a
+    // partial memcache restart or eviction.
+    cache_set('test_cid_clear1', $this->default_value, $this->default_bin);
+    $this->assertTrue($this->checkCacheExists('test_cid_clear1', $this->default_value), 'The cache was created successfully.');
+    cache_clear_all('test_', $this->default_bin, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear1', $this->default_value), 'The cache was cleared successfully.');
+    // Delete the wildcard manually to simulate an eviction.
+    $wildcard = '.wildcard-' . 'test_';
+    dmemcache_delete($wildcard, $this->default_bin);
+    // Reset the memcache_wildcards() static cache.
+    memcache_wildcards(FALSE, FALSE, FALSE, TRUE);
+    $this->assertFalse($this->checkCacheExists('test_cid_clear1', $this->default_value), 'The cache was cleared successfully.');
+  }
+}

--- a/html/sites/all/modules/contrib/memcache/tests/memcache_test.info
+++ b/html/sites/all/modules/contrib/memcache/tests/memcache_test.info
@@ -1,0 +1,11 @@
+name = Memcache test
+description = Support module for memcache testing.
+package = Testing
+core = 7.x
+hidden = TRUE
+
+; Information added by Drupal.org packaging script on 2020-07-17
+version = "7.x-1.8"
+core = "7.x"
+project = "memcache"
+datestamp = "1594981708"

--- a/html/sites/all/modules/contrib/memcache/tests/memcache_test.module
+++ b/html/sites/all/modules/contrib/memcache/tests/memcache_test.module
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Implements hook_menu().
+ */
+function memcache_test_menu() {
+  $items['memcache-test/lock-acquire'] = array(
+    'title' => 'Lock acquire',
+    'page callback' => 'memcache_test_lock_acquire',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  $items['memcache-test/lock-exit'] = array(
+    'title' => 'Lock acquire then exit',
+    'page callback' => 'memcache_test_lock_exit',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  $items['memcache-test/set/%'] = array(
+    'title' => 'Set a value with a key',
+    'page callback' => 'memcache_test_set',
+    'page arguments' => array(2, 3),
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  $items['memcache-test/get/%'] = array(
+    'title' => 'Get a value from the cache',
+    'page callback' => 'memcache_test_get',
+    'page arguments' => array(2),
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  $items['memcache-test/wildcard-clear/%'] = array(
+    'title' => 'Clear the cache with a wildcard',
+    'page callback' => 'memcache_test_wildcard_flush',
+    'page arguments' => array(2),
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  $items['memcache-test/clear/%'] = array(
+    'title' => 'Clear the cache with a wildcard',
+    'page callback' => 'memcache_test_clear',
+    'page arguments' => array(2),
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  $items['memcache-test/clear-cache'] = array(
+    'title' => 'Clear the cache with a wildcard',
+    'page callback' => 'memcache_test_clear_cache',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
+ * Try to acquire a named lock and report the outcome.
+ */
+function memcache_test_lock_acquire() {
+  if (lock_acquire('memcache_test_lock_acquire')) {
+    lock_release('memcache_test_lock_acquire');
+    return 'TRUE: Lock successfully acquired in memcache_test_lock_acquire()';
+  }
+  else {
+    return 'FALSE: Lock not acquired in memcache_test_lock_acquire()';
+  }
+}
+
+/**
+ * Try to acquire a specific lock, and then exit.
+ */
+function memcache_test_lock_exit() {
+  if (lock_acquire('memcache_test_lock_exit', 900)) {
+    echo 'TRUE: Lock successfully acquired in memcache_test_lock_exit()';
+    // The shut-down function should release the lock.
+    exit();
+  }
+  else {
+    return 'FALSE: Lock not acquired in memcache_test_lock_exit()';
+  }
+}
+
+/**
+ * Set a value into the cache.
+ */
+function memcache_test_set($key, $value) {
+  $cache = cache_set($key, $value, 'MemcacheDrupal');
+  drupal_json_output(cache_get($key, 'MemcacheDrupal'));
+}
+
+/**
+ * Set a value into the cache.
+ */
+function memcache_test_get($key) {
+  $GLOBALS['in_test'] = TRUE;
+  drupal_json_output(cache_get($key, 'MemcacheDrupal'));
+}
+
+/**
+ * Clear cache using a wildcard.
+ */
+function memcache_test_wildcard_flush($key) {
+  $_SESSION['cache_flush'] = array();
+  cache_clear_all($key, 'MemcacheDrupal', TRUE);
+  drupal_json_output($key);
+}
+
+/**
+ * Clear cache using a specific key.
+ */
+function memcache_test_clear($key) {
+  cache_clear_all($key, 'MemcacheDrupal');
+
+  drupal_json_output($key);
+}
+
+/**
+* Clear complete cache.
+*/
+function memcache_test_clear_cache() {
+  cache_clear_all(NULL, 'MemcacheDrupal');
+  drupal_json_output();
+}


### PR DESCRIPTION
This PR adds the memcache module. There is already a memcache container in the dev stack. After this code is deployed I will flip HR.info dev from redis to memcache for testing purposes. We'll see how we go for a week or two before touching prod (though this module is safe to merge to master and deploy to prod)