### PR TITLE
SNAP-75: fix render issues with PDF footer

### DIFF
--- a/html/sites/all/modules/hr/hr_events/hr_events.module
+++ b/html/sites/all/modules/hr/hr_events/hr_events.module
@@ -267,7 +267,7 @@ function hr_events_pdf_output($nid) {
   }
   .pdf-footer {
     display: table;
-    width: 100%;
+    width: 213mm; /* 297mm * 0.75 - 5mm - 5mm */
     margin: 0 5mm;
     white-space: nowrap;
 
@@ -297,7 +297,7 @@ PDF_FOOTER;
     'pdfFormat' => 'A4',
     'pdfLandscape' => 'true',
     'pdfBackground' => 'true',
-  // Suppress default by sending space character.
+    // Suppress default by sending space character.
     'pdfHeader' => ' ',
     'pdfFooter' => $pdf_footer,
     'pdfMarginTop' => '24',


### PR DESCRIPTION
During latest Snap upgrade, we noticed the PDF footer has a visual regression. It was reproduced on Snap dev, Snap prod, and on my local running a similar image to prod.

I couldn't nail down exactly why the regression crept in, but I fixed it by supplying a more specific width to the PDF footer via the inline CSS. I commented it to explain the magic number.

