### PR TITLE
[OPS-6982] Tell robots to not perform searches. At all.

### DIFF
--- a/html/robots.txt
+++ b/html/robots.txt
@@ -91,3 +91,10 @@ Disallow: /?q=user/login/
 Disallow: /?q=user/logout/
 Disallow: */calendar.ics/*
 Disallow: */events/pdf$
+# Searches (everywhere)
+Disallow: /en/search
+Disallow: /es/search
+Disallow: /fr/search
+Disallow: /ru/search
+Disallow: */search
+Disallow: *?search


### PR DESCRIPTION
Robots appear to be creating searches that hit the PHP memory_limit. They also use resources that better spent on actual people, so let's just tell them to leave.

See also https://github.com/UN-OCHA/hrinfo-stack/pull/91