### PR TITLE
[DOC-12] docstore script

### DIFF
--- a/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
+++ b/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
@@ -34,6 +34,11 @@ function hr_core_drush_command() {
         'description' => 'Vocabulary to create',
         'example-value' => 'Document type',
       ),
+      'cardinality' => array(
+        'description' => 'Whether documents can have multiple terms from this
+          vocabulary',
+        'example-value' => 'multiple',
+      ),
     ),
     'aliases' => array("hr-docs-voc"),
   );
@@ -43,9 +48,24 @@ function hr_core_drush_command() {
       Not needed for fields which reference vocabularies.",
     'drupal dependencies' => array(),
     'arguments' => array(
-      'field_name' => array(
+      'label' => array(
         'description' => 'Name of field to add',
         'example-value' => 'Document type',
+      ),
+      'type' => array(
+        'description' => '"target" or "type" for other fields field',
+        'example-value' => 'type',
+      ),
+      'value' => array(
+        'description' => 'Target name for vocab, or type',
+        'example-value' => 'integer',
+      ),
+    ),
+    'options' => array(
+      'cardinality' => array(
+        'description' => 'Whether documents can have multiple terms from this
+          vocabulary',
+        'example-value' => 'multiple',
       ),
     ),
     'aliases' => array("hr-docs-field"),
@@ -250,6 +270,7 @@ function drush_hr_core_docstore_create_vocab() {
   if (empty($vocab_name)) {
     drush_log(t('You need to specify a vocabulary name to create.'));
   }
+  $cardinality = drush_get_option('cardinality', 'single');
 
   $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
   $exists = drush_hr_core_docstore_call('GET', 'vocabularies/' . $prefix . strtolower($vocab_name));
@@ -261,7 +282,7 @@ function drush_hr_core_docstore_create_vocab() {
     $result = drush_hr_core_docstore_call('POST', 'vocabularies', json_encode($json));
 
     if (!empty($result->machine_name)) {
-      drush_hr_core_docstore_add_field($vocab_name, 'target', $result->machine_name);
+      drush_hr_core_docstore_add_field($vocab_name, 'target', $result->machine_name, $cardinality);
     }
   }
 }
@@ -269,7 +290,7 @@ function drush_hr_core_docstore_create_vocab() {
 /**
  * Add a field to document.
  */
-function drush_hr_core_docstore_add_field($label, $type, $value) {
+function drush_hr_core_docstore_add_field($label, $type, $value, $cardinality = 'single') {
 
   if (empty($label)) {
     drush_log(t('You need to specify a name for the field to add.'));
@@ -278,8 +299,9 @@ function drush_hr_core_docstore_add_field($label, $type, $value) {
     drush_log(t('You need to specify "type" or "target".'));
   }
   if (empty($value)) {
-    drush_log(t('You need to specify a type, or machine name for the field.'));
+    drush_log(t('You need to specify the type value, or the target.'));
   }
+  $cardinality_option = drush_get_option('cardinality', 'single');
 
   $fields = drush_hr_core_docstore_call('GET', 'document/fields');
   if (!in_array($value, array_keys((array) $fields))) {
@@ -287,7 +309,10 @@ function drush_hr_core_docstore_add_field($label, $type, $value) {
     $json->label = $label;
     $json->author = 'hrinfo';
     $json->$type = $value;
-
+    // TODO cardinality isn't working. Why not?
+    if ($cardinality === 'multiple' || $cardinality_option === 'multiple') {
+      $json->multiple = TRUE;
+    }
     drush_hr_core_docstore_call('POST', 'document/fields', json_encode($json));
   }
 }
@@ -351,59 +376,27 @@ function drush_hr_core_docstore_add_term($field_value, $vocab, &$context) {
 
     $created_term = drush_hr_core_docstore_call('POST', 'terms', json_encode($json));
     if (!empty($created_term->uuid)) {
-      $context['sandbox']['terms'][$vocab][$field_value] = $created_term->uuid;
+      $context['sandbox']['terms'][$vocab][] = $field_value;
     }
   }
 }
 
 /**
- * Handle new terms.
+ * Check new terms.
  */
-function drush_hr_core_docstore_handle_terms($wrapper, &$context) {
-  foreach ($context['sandbox']['vocabularies'] as $vocab) {
-    $fieldname = str_replace('hrinfo_', 'field_', $vocab->machine_name);
-    if ($fieldname === 'field_status') {
-      $fieldname = 'status';
-    }
-    if ($wrapper->$fieldname->value() != NULL) {
+function drush_hr_core_docstore_check_new_terms($field, $field_values, $context) {
 
-      // Get all terms for this vocabulary.
-      // TODO: this won't scale well - how to handle very large vocabularies?
-      if (empty($context['sandbox']['terms'][$vocab->machine_name])) {
-        $terms = drush_hr_core_docstore_call('GET', 'vocabularies/' . $vocab->machine_name . '/terms');
-        if (!empty($terms)) {
-          $term_names = array();
-          $prefix = $context['sandbox']['prefix'];
-          foreach ($terms as $term) {
-            if (strpos($term->vocabulary_name, $prefix) === 0) {
-              $term_names[$term->label] = $term->uuid;
-            }
-          }
-          $context['sandbox']['terms'][$vocab->machine_name] = $term_names;
-        }
-        else {
-          $context['sandbox']['terms'][$vocab->machine_name] = array();
-        }
-      }
+  if (empty($context['sandbox']['terms'][$field])) {
+    $terms = drush_hr_core_docstore_call('GET', 'vocabularies/' . $field . '/terms');
+    $term_names = array_map(function ($term) {
+      return $term->name;
+    }, $terms);
+    $context['sandbox']['terms'][$field] = $term_names;
+  }
 
-      // Create term name if we don't already have it.
-      if (isset($wrapper->$fieldname->value()->name)) {
-        $field_value = $wrapper->$fieldname->value()->name;
-
-        drush_hr_core_docstore_add_term($field_value, $vocab->machine_name, $context);
-      }
-      else {
-        if (is_array($wrapper->$fieldname->value())) {
-          foreach ($wrapper->$fieldname->value() as $value) {
-            if (isset($value->name)) {
-              drush_hr_core_docstore_add_term($value->name, $vocab->machine_name, $context);
-            }
-          }
-        }
-        else {
-          drush_hr_core_docstore_add_term($wrapper->$fieldname->value(), $vocab->machine_name, $context);
-        }
-      }
+  foreach ($field_values as $value) {
+    if (!in_array($value, $context['sandbox']['terms'][$field])) {
+      drush_hr_core_docstore_add_term($value, $field, $context);
     }
   }
 }
@@ -422,7 +415,7 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
       FROM {node}
       WHERE type = :bundle
       ORDER BY nid
-      DESC", 0, 1, array(':bundle' => $bundle)
+      DESC", $offset, 1, array(':bundle' => $bundle)
     )->fetchField();
     // Get vocabularies for bundle from docstore api.
     $vocabularies = drush_hr_core_docstore_get_vocabularies();
@@ -450,8 +443,6 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
   foreach ($results as $result) {
     $wrapper = entity_metadata_wrapper('node', $result->nid);
 
-    drush_hr_core_docstore_handle_terms($wrapper, $context);
-
     // Get all the fields for the property.
     $fields = drush_hr_core_docstore_call('GET', 'document/fields');
 
@@ -464,60 +455,69 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
     $json->title = $wrapper->label();
     $json->author = 'hrinfo';
 
-    // This is a bit messy. We add an id and then vocab references for
-    // entity reference fields, multiple entity reference fields, and the
-    // 'status' field (which doesn't have a name, and should probably be a
-    // string instead. It doesn't handle strings or dates.
     foreach ($property_fields as $field) {
-      if ($field === 'hrinfo_legacy_id') {
-        $json->metadata[] = array($field => $wrapper->getIdentifier());
+      $field_info = drush_hr_core_docstore_call('GET', 'document/fields/' . $field);
+      $ds_hr_map = array(
+        'hrinfo_status' => 'status',
+        'hrinfo_og_group_ref' => 'og_group_ref',
+        'hrinfo_group_content_access' => 'group_content_access',
+        'hrinfo_created' => 'created',
+        'hrinfo_changed' => 'changed',
+      );
+      if (in_array($field, array_keys($ds_hr_map))) {
+        $fieldname = $ds_hr_map[$field];
       }
       else {
         $fieldname = str_replace('hrinfo_', 'field_', $field);
-        if ($fieldname === 'field_status') {
-          $fieldname = 'status';
-        }
-        if (isset($wrapper->$fieldname) && !empty($wrapper->$fieldname->value())) {
-          if (isset($wrapper->$fieldname->value()->name)) {
-            $field_value = $wrapper->$fieldname->value()->name;
-            $json->metadata[] = array(
-              $field => array(
-                'target_uuid' => $context['sandbox']['terms'][$field][$field_value],
-              ),
-            );
-          }
-          else {
+      }
+
+      if ($field === 'hrinfo_id') {
+        $json->metadata[] = array($field => $wrapper->getIdentifier());
+      }
+      elseif (isset($wrapper->$fieldname) && !empty($wrapper->$fieldname->value())) {
+        if ($field_info->type === 'entity_reference_uuid') {
+          $label = $field . '_label';
+          if ($field_info->multiple) {
             $field_values = array();
             if (is_array($wrapper->$fieldname->value())) {
               foreach ($wrapper->$fieldname->value() as $value) {
-                if (isset($value->name)) {
-                  $field_values[] = $context['sandbox']['terms'][$field][$value->name];
+                if (!empty($value->name)) {
+                  $field_values[] = $value->name;
                 }
               }
-              $json->metadata[] = array(
-                $field => array(
-                  // TODO: Get this working for multiple values.
-                  // On creating a field, it expects just one value.
-                  'target_uuid' => $field_values[0],
-                ),
-              );
+              // Check field_Values exist as terms.
+              drush_hr_core_docstore_check_new_terms($field, $field_values, $context);
+              $json->metadata[] = array($label => $field_values);
             }
-            else {
-              $json->metadata[] = array(
-                $field => array(
-                  'target_uuid' => $context['sandbox']['terms'][$field][$wrapper->$fieldname->value()],
-                ),
-              );
+          }
+          elseif (isset($wrapper->$fieldname->value()->name)) {
+            $value = $wrapper->$fieldname->value()->name;
+            drush_hr_core_docstore_check_new_terms($field, array($value), $context);
+            // Check field_Value exists as a term.
+            $json->metadata[] = array(
+              $label => $value,
+            );
+          }
+        }
+        else {
+          if ($field_info->multiple) {
+            foreach ($wrapper->$fieldname->value() as $value) {
+              $field_values[] = $value;
             }
+            $json->metadata[] = array($field => $field_values);
+          }
+          else {
+            $json->metadata[] = array($field => $wrapper->$fieldname->value());
           }
         }
       }
     }
 
-    // @codingStandardsIgnoreLine
+    // @codingStandardsIgnoreStart
     //dd(json_encode($json), 'json with metadata');
-
-    drush_hr_core_docstore_call('POST', 'documents', json_encode($json));
+    $created = drush_hr_core_docstore_call('POST', 'documents', json_encode($json));
+    //dd($created, 'created');
+    // @codingStandardsIgnoreEnd
 
     $context['sandbox']['progress']++;
     $context['sandbox']['current_entity_id'] = $result->nid;

--- a/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
+++ b/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
@@ -465,6 +465,10 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
     $json->title = $wrapper->label();
     $json->author = 'hrinfo';
 
+    // This is a bit messy. We add an id and then vocab references for
+    // entity reference fields, multiple entity reference fields, and the
+    // 'status' field (which doesn't have a name, and should probably be a
+    // string instead. It doesn't handle strings or dates.
     foreach ($property_fields as $field) {
       if ($field === 'hrinfo_legacy_id') {
         $json->metadata[] = array($field => $wrapper->getIdentifier());

--- a/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
+++ b/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
@@ -458,11 +458,12 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
     foreach ($property_fields as $field) {
       $field_info = drush_hr_core_docstore_call('GET', 'document/fields/' . $field);
       $ds_hr_map = array(
-        'hrinfo_status' => 'status',
-        'hrinfo_og_group_ref' => 'og_group_ref',
-        'hrinfo_group_content_access' => 'group_content_access',
-        'hrinfo_created' => 'created',
+        'hrinfo_body' => 'body',
         'hrinfo_changed' => 'changed',
+        'hrinfo_created' => 'created',
+        'hrinfo_group_content_access' => 'group_content_access',
+        'hrinfo_og_group_ref' => 'og_group_ref',
+        'hrinfo_status' => 'status',
       );
       if (in_array($field, array_keys($ds_hr_map))) {
         $fieldname = $ds_hr_map[$field];
@@ -505,6 +506,9 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
               $field_values[] = $value;
             }
             $json->metadata[] = array($field => $field_values);
+          }
+          elseif ($field_info->type === 'string_long') {
+            $json->metadata[] = array($field => $wrapper->$fieldname->value()['value']);
           }
           else {
             $json->metadata[] = array($field => $wrapper->$fieldname->value());

--- a/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
+++ b/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
@@ -252,8 +252,8 @@ function drush_hr_core_docstore_create_vocab() {
   }
 
   $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
-  $exists = drush_hr_core_docstore_call('GET', 'vocabularies/' . $prefix . $vocab_name);
-  if (empty($exists['uuid'])) {
+  $exists = drush_hr_core_docstore_call('GET', 'vocabularies/' . $prefix . strtolower($vocab_name));
+  if (empty($exists->uuid)) {
     $json = new \stdClass();
     $json->label = $vocab_name;
     $json->author = 'hrinfo';
@@ -296,7 +296,6 @@ function drush_hr_core_docstore_add_field($label, $type, $value) {
  * Get vocabularies for the property.
  */
 function drush_hr_core_docstore_get_vocabularies() {
-
   $response = drush_hr_core_docstore_call('GET', 'vocabularies');
   $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
 

--- a/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
+++ b/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
@@ -202,64 +202,6 @@ function drush_hr_core_operation_avg_file_size() {
 }
 
 /**
- * Call docstore API.
- */
-function drush_hr_core_docstore_call($type, $path, $params = NULL) {
-  $url = variable_get('docstore_api_url',
-    'https://ocha:dev@dev.docstore-unocha-org.ahconu.org/api/') . $path;
-
-  $headers = array(
-    'Accept: application/json',
-    'Content-Type: application/json',
-  );
-
-  $ch = curl_init();
-
-  switch ($type) {
-    case 'POST':
-      curl_setopt($ch, CURLOPT_POST, 1);
-      curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
-      curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
-      $headers[] = 'API-KEY: ' . variable_get('hrinfo_docstore_write_api_key',
-        'hrinfo-456');
-      break;
-
-    case 'GET':
-      $headers[] = 'API-KEY: ' . variable_get('hrinfo_docstore_read_api_key',
-        'hrinfo-123');
-
-      break;
-  }
-  // Set URL and other appropriate options.
-  curl_setopt($ch, CURLOPT_URL, $url);
-  curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-  curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-  curl_setopt($ch, CURLOPT_FAILONERROR, TRUE);
-  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
-  // @codingStandardsIgnoreLine
-  //curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
-  // @codingStandardsIgnoreLine
-  //curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
-
-  $response = curl_exec($ch);
-
-  // Log errors to watchdog.
-  if ($response === FALSE || curl_errno($ch)) {
-    watchdog('hr_core_docstore_vocab', 'Curl HTTP code: @code', array(
-      '@code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
-    ));
-    watchdog('hr_core_docstore_vocab', 'Curl error: @error', array(
-      '@error' => curl_error($ch),
-    ));
-  }
-
-  // Close cURL resource, and free up system resources.
-  curl_close($ch);
-
-  return json_decode($response);
-}
-
-/**
  * Create a docstore vocabulary.
  */
 function drush_hr_core_docstore_create_vocab() {
@@ -273,16 +215,16 @@ function drush_hr_core_docstore_create_vocab() {
   $cardinality = drush_get_option('cardinality', 'single');
 
   $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
-  $exists = drush_hr_core_docstore_call('GET', 'vocabularies/' . $prefix . strtolower($vocab_name));
-  if (empty($exists->uuid)) {
+  $exists = hr_docstore_call_api('GET', 'vocabularies/' . $prefix . strtolower($vocab_name));
+  if (empty($exists['uuid'])) {
     $json = new \stdClass();
     $json->label = $vocab_name;
     $json->author = 'hrinfo';
 
-    $result = drush_hr_core_docstore_call('POST', 'vocabularies', json_encode($json));
+    $result = hr_docstore_call_api('POST', 'vocabularies', json_encode($json));
 
-    if (!empty($result->machine_name)) {
-      drush_hr_core_docstore_add_field($vocab_name, 'target', $result->machine_name, $cardinality);
+    if (!empty($result['machine_name'])) {
+      drush_hr_core_docstore_add_field($vocab_name, 'target', $result['machine_name'], $cardinality);
     }
   }
 }
@@ -303,30 +245,17 @@ function drush_hr_core_docstore_add_field($label, $type, $value, $cardinality = 
   }
   $cardinality_option = drush_get_option('cardinality', 'single');
 
-  $fields = drush_hr_core_docstore_call('GET', 'document/fields');
-  if (!in_array($value, array_keys((array) $fields))) {
+  $fields = hr_docstore_call_api('GET', 'fields/documents');
+  if (!in_array($value, array_keys($fields))) {
     $json = new \stdClass();
     $json->label = $label;
     $json->author = 'hrinfo';
     $json->$type = $value;
-    // TODO cardinality isn't working. Why not?
     if ($cardinality === 'multiple' || $cardinality_option === 'multiple') {
       $json->multiple = TRUE;
     }
-    drush_hr_core_docstore_call('POST', 'document/fields', json_encode($json));
+    hr_docstore_call_api('POST', 'fields/documents', json_encode($json));
   }
-}
-
-/**
- * Get vocabularies for the property.
- */
-function drush_hr_core_docstore_get_vocabularies() {
-  $response = drush_hr_core_docstore_call('GET', 'vocabularies');
-  $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
-
-  return array_filter(array_map(function ($vocab) use ($prefix) {
-    return strpos($vocab->machine_name, $prefix) === 0 ? $vocab : NULL;
-  }, $response));
 }
 
 /**
@@ -364,44 +293,6 @@ function drush_hr_core_docstore_populate() {
 }
 
 /**
- * Add term to vocab, if it doesn't exist.
- */
-function drush_hr_core_docstore_add_term($field_value, $vocab, &$context) {
-  if (is_array($context['sandbox']['terms'][$vocab]) &&
-    !in_array($field_value, array_keys($context['sandbox']['terms'][$vocab]))) {
-    $json = new \stdClass();
-    $json->label = $field_value;
-    $json->vocabulary = $vocab;
-    $json->author = 'hrinfo';
-
-    $created_term = drush_hr_core_docstore_call('POST', 'terms', json_encode($json));
-    if (!empty($created_term->uuid)) {
-      $context['sandbox']['terms'][$vocab][] = $field_value;
-    }
-  }
-}
-
-/**
- * Check new terms.
- */
-function drush_hr_core_docstore_check_new_terms($field, $field_values, $context) {
-
-  if (empty($context['sandbox']['terms'][$field])) {
-    $terms = drush_hr_core_docstore_call('GET', 'vocabularies/' . $field . '/terms');
-    $term_names = array_map(function ($term) {
-      return $term->name;
-    }, $terms);
-    $context['sandbox']['terms'][$field] = $term_names;
-  }
-
-  foreach ($field_values as $value) {
-    if (!in_array($value, $context['sandbox']['terms'][$field])) {
-      drush_hr_core_docstore_add_term($value, $field, $context);
-    }
-  }
-}
-
-/**
  * Batch handler.
  */
 function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &$context) {
@@ -417,16 +308,30 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
       ORDER BY nid
       DESC", $offset, 1, array(':bundle' => $bundle)
     )->fetchField();
-    // Get vocabularies for bundle from docstore api.
-    $vocabularies = drush_hr_core_docstore_get_vocabularies();
-    $context['sandbox']['vocabularies'] = $vocabularies;
     $context['sandbox']['current_entity_id'] = $start;
     $context['sandbox']['max'] = $limit;
     $context['sandbox']['terms'] = array();
     $context['message'] = 'Starting push of documents to docstore.';
     $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
     $context['sandbox']['prefix'] = $prefix;
+    // Get all the fields for the property.
+    $fields = hr_docstore_call_api('GET', 'fields/documents');
+
+    $prefix = $context['sandbox']['prefix'];
+    $field_array = array();
+    $property_fields = array_filter(array_map(function ($field) use ($prefix) {
+      return (strpos($field, $prefix) === 0 || strpos($field, 'base_') === 0) ? $field : NULL;
+    }, array_keys($fields)));
+    $context['sandbox']['property_fields'] = $property_fields;
+    foreach ($property_fields as $field) {
+      $field_info = hr_docstore_call_api('GET', 'fields/documents/' . $field);
+      $field_array[$field] = $field_info;
+    }
+    $context['sandbox']['field_array'] = $field_array;
   }
+
+  $property_fields = $context['sandbox']['property_fields'];
+  $field_array = $context['sandbox']['field_array'];
 
   // Select the next batch.
   $batch_limit = $limit > 50 ? 50 : $limit;
@@ -443,85 +348,7 @@ function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &
   foreach ($results as $result) {
     $wrapper = entity_metadata_wrapper('node', $result->nid);
 
-    // Get all the fields for the property.
-    $fields = drush_hr_core_docstore_call('GET', 'document/fields');
-
-    $prefix = $context['sandbox']['prefix'];
-    $property_fields = array_filter(array_map(function ($field) use ($prefix) {
-      return strpos($field, $prefix) === 0 ? $field : NULL;
-    }, array_keys((array) $fields)));
-
-    $json = new \stdClass();
-    $json->title = $wrapper->label();
-    $json->author = 'hrinfo';
-
-    foreach ($property_fields as $field) {
-      $field_info = drush_hr_core_docstore_call('GET', 'document/fields/' . $field);
-      $ds_hr_map = array(
-        'hrinfo_body' => 'body',
-        'hrinfo_changed' => 'changed',
-        'hrinfo_created' => 'created',
-        'hrinfo_group_content_access' => 'group_content_access',
-        'hrinfo_og_group_ref' => 'og_group_ref',
-        'hrinfo_status' => 'status',
-      );
-      if (in_array($field, array_keys($ds_hr_map))) {
-        $fieldname = $ds_hr_map[$field];
-      }
-      else {
-        $fieldname = str_replace('hrinfo_', 'field_', $field);
-      }
-
-      if ($field === 'hrinfo_id') {
-        $json->metadata[] = array($field => $wrapper->getIdentifier());
-      }
-      elseif (isset($wrapper->$fieldname) && !empty($wrapper->$fieldname->value())) {
-        if ($field_info->type === 'entity_reference_uuid') {
-          $label = $field . '_label';
-          if ($field_info->multiple) {
-            $field_values = array();
-            if (is_array($wrapper->$fieldname->value())) {
-              foreach ($wrapper->$fieldname->value() as $value) {
-                if (!empty($value->name)) {
-                  $field_values[] = $value->name;
-                }
-              }
-              // Check field_Values exist as terms.
-              drush_hr_core_docstore_check_new_terms($field, $field_values, $context);
-              $json->metadata[] = array($label => $field_values);
-            }
-          }
-          elseif (isset($wrapper->$fieldname->value()->name)) {
-            $value = $wrapper->$fieldname->value()->name;
-            drush_hr_core_docstore_check_new_terms($field, array($value), $context);
-            // Check field_Value exists as a term.
-            $json->metadata[] = array(
-              $label => $value,
-            );
-          }
-        }
-        else {
-          if ($field_info->multiple) {
-            foreach ($wrapper->$fieldname->value() as $value) {
-              $field_values[] = $value;
-            }
-            $json->metadata[] = array($field => $field_values);
-          }
-          elseif ($field_info->type === 'string_long') {
-            $json->metadata[] = array($field => $wrapper->$fieldname->value()['value']);
-          }
-          else {
-            $json->metadata[] = array($field => $wrapper->$fieldname->value());
-          }
-        }
-      }
-    }
-
-    // @codingStandardsIgnoreStart
-    //dd(json_encode($json), 'json with metadata');
-    $created = drush_hr_core_docstore_call('POST', 'documents', json_encode($json));
-    //dd($created, 'created');
-    // @codingStandardsIgnoreEnd
+    hr_docstore_create($property_fields, $field_array, $wrapper);
 
     $context['sandbox']['progress']++;
     $context['sandbox']['current_entity_id'] = $result->nid;

--- a/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
+++ b/html/sites/all/modules/hr/hr_core/hr_core.drush.inc
@@ -8,9 +8,6 @@
 /**
  * Implements hook_drush_command().
  *
- * @return array
- *   An associative array describing your command(s).
- *
  * @see drush_parse_command()
  */
 function hr_core_drush_command() {
@@ -26,6 +23,54 @@ function hr_core_drush_command() {
     'description' => "Display the average file size and median of the files for an operation",
     'drupal dependencies' => array(),
     'aliases' => array(),
+  );
+
+  $items['hr-core-docstore-create-vocab'] = array(
+    'description' => "Create a vocabulary in the docstore via its API, and
+      associated fields on the document bundle.",
+    'drupal dependencies' => array(),
+    'options' => array(
+      'vocab' => array(
+        'description' => 'Vocabulary to create',
+        'example-value' => 'Document type',
+      ),
+    ),
+    'aliases' => array("hr-docs-voc"),
+  );
+
+  $items['hr-core-docstore-add-field'] = array(
+    'description' => "Add a field to documents in the docstore via its API.
+      Not needed for fields which reference vocabularies.",
+    'drupal dependencies' => array(),
+    'arguments' => array(
+      'field_name' => array(
+        'description' => 'Name of field to add',
+        'example-value' => 'Document type',
+      ),
+    ),
+    'aliases' => array("hr-docs-field"),
+  );
+
+  $items['hr-core-docstore-populate'] = array(
+    'description' => "Put documents in the docstore via its API.
+      First, create relevant vocabularies and fields.
+      N.B. Make sure to clear the docstore site cache before running this!",
+    'drupal dependencies' => array(),
+    'options' => array(
+      'bundle' => array(
+        'description' => 'The node type to push',
+        'example-value' => 'hr_document',
+      ),
+      'offset' => array(
+        'description' => 'The number of documents to skip',
+        'example-value' => '20',
+      ),
+      'limit' => array(
+        'description' => 'The number of documents to push',
+        'example-value' => '20',
+      ),
+    ),
+    'aliases' => array("hr-docs-pop"),
   );
 
   return $items;
@@ -122,7 +167,7 @@ function drush_hr_core_operation_avg_file_size() {
 
       // Compute median file size.
       $result = db_query('SELECT percentile_disc(0.5) within group (order by filesize) FROM drupal.file_managed WHERE fid IN (:fids);', array(
-        ':fids' => $file_ids
+        ':fids' => $file_ids,
       ));
       foreach ($result as $record) {
         print_r($record);
@@ -134,4 +179,366 @@ function drush_hr_core_operation_avg_file_size() {
   else {
     drush_print('No operation provided');
   }
+}
+
+/**
+ * Call docstore API.
+ */
+function drush_hr_core_docstore_call($type, $path, $params = NULL) {
+  $url = variable_get('docstore_api_url',
+    'https://ocha:dev@dev.docstore-unocha-org.ahconu.org/api/') . $path;
+
+  $headers = array(
+    'Accept: application/json',
+    'Content-Type: application/json',
+  );
+
+  $ch = curl_init();
+
+  switch ($type) {
+    case 'POST':
+      curl_setopt($ch, CURLOPT_POST, 1);
+      curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+      curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+      $headers[] = 'API-KEY: ' . variable_get('hrinfo_docstore_write_api_key',
+        'hrinfo-456');
+      break;
+
+    case 'GET':
+      $headers[] = 'API-KEY: ' . variable_get('hrinfo_docstore_read_api_key',
+        'hrinfo-123');
+
+      break;
+  }
+  // Set URL and other appropriate options.
+  curl_setopt($ch, CURLOPT_URL, $url);
+  curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+  curl_setopt($ch, CURLOPT_FAILONERROR, TRUE);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+  // @codingStandardsIgnoreLine
+  //curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+  // @codingStandardsIgnoreLine
+  //curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+
+  $response = curl_exec($ch);
+
+  // Log errors to watchdog.
+  if ($response === FALSE || curl_errno($ch)) {
+    watchdog('hr_core_docstore_vocab', 'Curl HTTP code: @code', array(
+      '@code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
+    ));
+    watchdog('hr_core_docstore_vocab', 'Curl error: @error', array(
+      '@error' => curl_error($ch),
+    ));
+  }
+
+  // Close cURL resource, and free up system resources.
+  curl_close($ch);
+
+  return json_decode($response);
+}
+
+/**
+ * Create a docstore vocabulary.
+ */
+function drush_hr_core_docstore_create_vocab() {
+
+  drush_log(t('Will create vocab on docstore.'));
+
+  $vocab_name = drush_get_option('vocab', '');
+  if (empty($vocab_name)) {
+    drush_log(t('You need to specify a vocabulary name to create.'));
+  }
+
+  $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
+  $exists = drush_hr_core_docstore_call('GET', 'vocabularies/' . $prefix . $vocab_name);
+  if (empty($exists['uuid'])) {
+    $json = new \stdClass();
+    $json->label = $vocab_name;
+    $json->author = 'hrinfo';
+
+    $result = drush_hr_core_docstore_call('POST', 'vocabularies', json_encode($json));
+
+    if (!empty($result->machine_name)) {
+      drush_hr_core_docstore_add_field($vocab_name, 'target', $result->machine_name);
+    }
+  }
+}
+
+/**
+ * Add a field to document.
+ */
+function drush_hr_core_docstore_add_field($label, $type, $value) {
+
+  if (empty($label)) {
+    drush_log(t('You need to specify a name for the field to add.'));
+  }
+  if (empty($type)) {
+    drush_log(t('You need to specify "type" or "target".'));
+  }
+  if (empty($value)) {
+    drush_log(t('You need to specify a type, or machine name for the field.'));
+  }
+
+  $fields = drush_hr_core_docstore_call('GET', 'document/fields');
+  if (!in_array($value, array_keys((array) $fields))) {
+    $json = new \stdClass();
+    $json->label = $label;
+    $json->author = 'hrinfo';
+    $json->$type = $value;
+
+    drush_hr_core_docstore_call('POST', 'document/fields', json_encode($json));
+  }
+}
+
+/**
+ * Get vocabularies for the property.
+ */
+function drush_hr_core_docstore_get_vocabularies() {
+
+  $response = drush_hr_core_docstore_call('GET', 'vocabularies');
+  $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
+
+  return array_filter(array_map(function ($vocab) use ($prefix) {
+    return strpos($vocab->machine_name, $prefix) === 0 ? $vocab : NULL;
+  }, $response));
+}
+
+/**
+ * Push documents to the docstore.
+ */
+function drush_hr_core_docstore_populate() {
+  if (!drush_bootstrap_to_phase(DRUSH_BOOTSTRAP_DRUPAL_DATABASE)) {
+    return drush_set_error('DRUPAL_SITE_NOT_FOUND',
+      dt('You need to specify an alias or run this command within a site.')
+    );
+  }
+
+  $bundle = drush_get_option('bundle', 'hr_document');
+  $offset = drush_get_option('offset', '0');
+  $default_limit = db_query("
+    SELECT nid
+    FROM node
+    WHERE type = :bundle", array(':bundle' => $bundle)
+  )->rowCount();
+  $limit = drush_get_option('limit', $default_limit);
+
+  $batch = array(
+    'title' => t('Pushing documents to docstore'),
+    'operations' => array(
+      array(
+        'drush_hr_core_docstore_push_batch_operation',
+        array($bundle, $offset, $limit),
+      ),
+    ),
+    'finished' => 'drush_hr_core_docstore_push_batch_finished',
+  );
+  batch_set($batch);
+  $batch =& batch_get();
+  drush_backend_batch_process();
+}
+
+/**
+ * Add term to vocab, if it doesn't exist.
+ */
+function drush_hr_core_docstore_add_term($field_value, $vocab, &$context) {
+  if (is_array($context['sandbox']['terms'][$vocab]) &&
+    !in_array($field_value, array_keys($context['sandbox']['terms'][$vocab]))) {
+    $json = new \stdClass();
+    $json->label = $field_value;
+    $json->vocabulary = $vocab;
+    $json->author = 'hrinfo';
+
+    $created_term = drush_hr_core_docstore_call('POST', 'terms', json_encode($json));
+    if (!empty($created_term->uuid)) {
+      $context['sandbox']['terms'][$vocab][$field_value] = $created_term->uuid;
+    }
+  }
+}
+
+/**
+ * Handle new terms.
+ */
+function drush_hr_core_docstore_handle_terms($wrapper, &$context) {
+  foreach ($context['sandbox']['vocabularies'] as $vocab) {
+    $fieldname = str_replace('hrinfo_', 'field_', $vocab->machine_name);
+    if ($fieldname === 'field_status') {
+      $fieldname = 'status';
+    }
+    if ($wrapper->$fieldname->value() != NULL) {
+
+      // Get all terms for this vocabulary.
+      // TODO: this won't scale well - how to handle very large vocabularies?
+      if (empty($context['sandbox']['terms'][$vocab->machine_name])) {
+        $terms = drush_hr_core_docstore_call('GET', 'vocabularies/' . $vocab->machine_name . '/terms');
+        if (!empty($terms)) {
+          $term_names = array();
+          $prefix = $context['sandbox']['prefix'];
+          foreach ($terms as $term) {
+            if (strpos($term->vocabulary_name, $prefix) === 0) {
+              $term_names[$term->label] = $term->uuid;
+            }
+          }
+          $context['sandbox']['terms'][$vocab->machine_name] = $term_names;
+        }
+        else {
+          $context['sandbox']['terms'][$vocab->machine_name] = array();
+        }
+      }
+
+      // Create term name if we don't already have it.
+      if (isset($wrapper->$fieldname->value()->name)) {
+        $field_value = $wrapper->$fieldname->value()->name;
+
+        drush_hr_core_docstore_add_term($field_value, $vocab->machine_name, $context);
+      }
+      else {
+        if (is_array($wrapper->$fieldname->value())) {
+          foreach ($wrapper->$fieldname->value() as $value) {
+            if (isset($value->name)) {
+              drush_hr_core_docstore_add_term($value->name, $vocab->machine_name, $context);
+            }
+          }
+        }
+        else {
+          drush_hr_core_docstore_add_term($wrapper->$fieldname->value(), $vocab->machine_name, $context);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Batch handler.
+ */
+function drush_hr_core_docstore_push_batch_operation($bundle, $offset, $limit, &$context) {
+
+  // Initiate multistep processing.
+  if (empty($context['sandbox'])) {
+    $context['sandbox']['progress'] = 0;
+    // Index more recent documents first.
+    $start = db_query_range("
+      SELECT nid
+      FROM {node}
+      WHERE type = :bundle
+      ORDER BY nid
+      DESC", 0, 1, array(':bundle' => $bundle)
+    )->fetchField();
+    // Get vocabularies for bundle from docstore api.
+    $vocabularies = drush_hr_core_docstore_get_vocabularies();
+    $context['sandbox']['vocabularies'] = $vocabularies;
+    $context['sandbox']['current_entity_id'] = $start;
+    $context['sandbox']['max'] = $limit;
+    $context['sandbox']['terms'] = array();
+    $context['message'] = 'Starting push of documents to docstore.';
+    $prefix = variable_get('docstore_property_prefix', 'hrinfo_');
+    $context['sandbox']['prefix'] = $prefix;
+  }
+
+  // Select the next batch.
+  $batch_limit = $limit > 50 ? 50 : $limit;
+  $results = db_query_range(
+    "SELECT nid FROM {node}
+    WHERE nid < :entity_id
+      AND type = :bundle
+    ORDER BY nid
+    DESC", 0, $batch_limit, array(
+      ':entity_id' => $context['sandbox']['current_entity_id'],
+      ':bundle' => $bundle,
+    ))->fetchAll();
+
+  foreach ($results as $result) {
+    $wrapper = entity_metadata_wrapper('node', $result->nid);
+
+    drush_hr_core_docstore_handle_terms($wrapper, $context);
+
+    // Get all the fields for the property.
+    $fields = drush_hr_core_docstore_call('GET', 'document/fields');
+
+    $prefix = $context['sandbox']['prefix'];
+    $property_fields = array_filter(array_map(function ($field) use ($prefix) {
+      return strpos($field, $prefix) === 0 ? $field : NULL;
+    }, array_keys((array) $fields)));
+
+    $json = new \stdClass();
+    $json->title = $wrapper->label();
+    $json->author = 'hrinfo';
+
+    foreach ($property_fields as $field) {
+      if ($field === 'hrinfo_legacy_id') {
+        $json->metadata[] = array($field => $wrapper->getIdentifier());
+      }
+      else {
+        $fieldname = str_replace('hrinfo_', 'field_', $field);
+        if ($fieldname === 'field_status') {
+          $fieldname = 'status';
+        }
+        if (isset($wrapper->$fieldname) && !empty($wrapper->$fieldname->value())) {
+          if (isset($wrapper->$fieldname->value()->name)) {
+            $field_value = $wrapper->$fieldname->value()->name;
+            $json->metadata[] = array(
+              $field => array(
+                'target_uuid' => $context['sandbox']['terms'][$field][$field_value],
+              ),
+            );
+          }
+          else {
+            $field_values = array();
+            if (is_array($wrapper->$fieldname->value())) {
+              foreach ($wrapper->$fieldname->value() as $value) {
+                if (isset($value->name)) {
+                  $field_values[] = $context['sandbox']['terms'][$field][$value->name];
+                }
+              }
+              $json->metadata[] = array(
+                $field => array(
+                  // TODO: Get this working for multiple values.
+                  // On creating a field, it expects just one value.
+                  'target_uuid' => $field_values[0],
+                ),
+              );
+            }
+            else {
+              $json->metadata[] = array(
+                $field => array(
+                  'target_uuid' => $context['sandbox']['terms'][$field][$wrapper->$fieldname->value()],
+                ),
+              );
+            }
+          }
+        }
+      }
+    }
+
+    // @codingStandardsIgnoreLine
+    //dd(json_encode($json), 'json with metadata');
+
+    drush_hr_core_docstore_call('POST', 'documents', json_encode($json));
+
+    $context['sandbox']['progress']++;
+    $context['sandbox']['current_entity_id'] = $result->nid;
+  }
+
+  // Multistep processing : report progress.
+  if (!empty($results) && $context['sandbox']['progress'] <= $context['sandbox']['max']) {
+    $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+    $context['message'] = 'Progress ' . $context['sandbox']['progress'] . '/' . $context['sandbox']['max'];
+  }
+  else {
+    $context['finished'] = TRUE;
+  }
+}
+
+/**
+ * Finished callback.
+ */
+function drush_hr_core_docstore_push_batch_finished($success, $results, $operations) {
+  if ($success) {
+    drush_log(t('The documents have been pushed to the docstore.'));
+  }
+  else {
+    drush_log(t('There was an error pushing documents to the docstore.'), 'error');
+  }
+  cache_clear_all();
 }

--- a/html/sites/all/modules/hr/hr_docstore/hr_docstore.info
+++ b/html/sites/all/modules/hr/hr_docstore/hr_docstore.info
@@ -1,0 +1,4 @@
+name = HR Docstore
+description = Docstore integration for Humanitarianresponse
+core = 7.x
+package = Humanitarianresponse

--- a/html/sites/all/modules/hr/hr_docstore/hr_docstore.module
+++ b/html/sites/all/modules/hr/hr_docstore/hr_docstore.module
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * @file
+ * Code for the docstore integration.
+ */
+
+/**
+ * Call docstore API.
+ */
+function hr_docstore_call_api($type, $path, $params = NULL) {
+  $url = variable_get('docstore_api_url',
+    'https://ocha:dev@dev.docstore-unocha-org.ahconu.org/api/') . $path;
+
+  // @codingStandardsIgnoreLine
+  $headers = array(
+    'Accept: application/json',
+    'Content-Type: application/json',
+  );
+
+  $ch = curl_init();
+
+  switch ($type) {
+    case 'POST':
+      curl_setopt($ch, CURLOPT_POST, 1);
+      curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+      curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+      $headers[] = 'API-KEY: ' . variable_get('hr_docstore_write_api_key',
+        'hrinfo-456');
+      break;
+
+    case 'GET':
+      $headers[] = 'API-KEY: ' . variable_get('hr_docstore_read_api_key',
+        'hrinfo-123');
+
+      break;
+  }
+  // Set URL and other appropriate options.
+  curl_setopt($ch, CURLOPT_URL, $url);
+  curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+  curl_setopt($ch, CURLOPT_FAILONERROR, TRUE);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
+  // @codingStandardsIgnoreLine
+  //curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+  // @codingStandardsIgnoreLine
+  //curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+
+  $response = curl_exec($ch);
+
+  // Log errors to watchdog.
+  if ($response === FALSE || curl_errno($ch)) {
+    watchdog('hr_docstore', 'Curl HTTP code: @code', array(
+      '@code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
+    ));
+    watchdog('hr_docstore', 'type: @type', array('@type' => $type));
+    watchdog('hr_docstore', 'path: @path', array('@path' => $path));
+    // @codingStandardsIgnoreLine
+    //dd($params, 'params with an error');
+    watchdog('hr_docstore', 'Curl error: @error', array(
+      '@error' => curl_error($ch),
+    ));
+  }
+
+  // Close cURL resource, and free up system resources.
+  curl_close($ch);
+
+  return drupal_json_decode($response);
+}
+
+/**
+ * Create new document.
+ */
+function hr_docstore_create($fields, $field_array, $wrapper) {
+
+  $field_map = array(
+    'base_files' => 'field_files_collection',
+    'hrinfo_body' => 'body',
+    'hrinfo_changed' => 'changed',
+    'hrinfo_countries' => 'field_locations',
+    'hrinfo_created' => 'created',
+    'hrinfo_group_content_access' => 'group_content_access',
+    'hrinfo_id' => 'nid',
+    'hrinfo_operations' => 'og_group_ref',
+    'hrinfo_status' => 'status',
+    'hrinfo_title' => 'title_field',
+  );
+
+  $json = new \stdClass();
+  $json->title = $wrapper->label();
+  $json->author = 'hrinfo';
+
+  foreach ($fields as $field) {
+    $field_info = $field_array[$field];
+    if (in_array($field, array_keys($field_map))) {
+      $fieldname = $field_map[$field];
+    }
+    else {
+      if (strpos($field, 'base_') === 0) {
+        continue;
+      }
+      $fieldname = str_replace('hrinfo_', 'field_', $field);
+    }
+
+    if ($field_info['type'] === 'entity_reference_uuid') {
+      $label = $field . '_label';
+      $field_values = array();
+      switch ($wrapper->$fieldname->type()) {
+        // This is for files.
+        // @todo It doesn't handle duplicates, yet.
+        case 'list<field_collection_item>':
+          if (is_array($wrapper->$fieldname->value())) {
+            $json->files = array();
+            foreach ($wrapper->$fieldname->value() as $value) {
+              if (empty($value->field_file) || empty($value->field_file[LANGUAGE_NONE])) {
+                break;
+              }
+              $files = $value->field_file[LANGUAGE_NONE];
+              // This is for use on other instances than prod.
+              $prod_files_dir = variable_get('hrinfo_prod_files_dir', 'https://www.humanitarianresponse.info/sites/www.humanitarianresponse.info/files/');
+              foreach ($files as $file) {
+                if (empty($file['uri'])) {
+                  continue;
+                }
+                // Transform uri to that of prod.
+                $prod_uri = str_replace('public://', $prod_files_dir, $file['uri']);
+                $json->files[] = array('uri' => $prod_uri);
+              }
+            }
+          }
+          break;
+
+        case 'list<node>':
+          if ($fieldname === 'field_disasters') {
+            // @todo Get disasters matched and working.
+            continue;
+          }
+          foreach ($wrapper->$fieldname->value() as $value) {
+            $value_wrapper = entity_metadata_wrapper('node', $value->nid);
+            $field_values[] = $value_wrapper->label();
+          }
+          break;
+
+        case 'list<taxonomy_term>':
+          foreach ($wrapper->$fieldname->value() as $value) {
+            $value_wrapper = entity_metadata_wrapper('taxonomy_term', $value->tid);
+            // Only locations with an iso3.
+            // @todo evaluate storing other locations in another field.
+            if ($field_info['label'] === 'countries' &&
+              $value_wrapper->field_iso3->value() === NULL) {
+              continue;
+            }
+            $field_values[] = $value_wrapper->label();
+          }
+          break;
+
+        case 'taxonomy_term':
+          $value = $wrapper->$fieldname->value();
+          $value_wrapper = entity_metadata_wrapper('taxonomy_term', $value->tid);
+          $field_values = $value_wrapper->label();
+          break;
+
+      }
+    }
+    else {
+      $label = $field;
+      switch ($wrapper->$fieldname->type()) {
+        case 'boolean':
+        case 'date':
+        case 'integer':
+        case 'taxonomy_term':
+        case 'text':
+          $field_values = $wrapper->$fieldname->value();
+          break;
+
+        case 'text_formatted':
+          $field_values = $wrapper->$fieldname->value()['value'];
+          break;
+
+      }
+    }
+
+    if (!empty($field_values)) {
+      $json->metadata[] = array($label => $field_values);
+      unset($field_values);
+    }
+  }
+
+  // @codingStandardsIgnoreStart
+  //dd(json_encode($json), 'json with metadata');
+  $created = hr_docstore_call_api('POST', 'documents', json_encode($json));
+  //dd($created, 'created');
+  // @codingStandardsIgnoreEnd
+
+  return 'something indicative of success';
+}


### PR DESCRIPTION
Still very WIP, this adds HRinfo content to the docstore.

To use:
* First make vocabularies e.g `drush hr-docs-voc --vocab="Organizations"` this creates related fields too. (Some vocabs are already on the dev site)
* Then add other fields that aren't vocab-related. e.g `drush hr-docs-field legacy_id type integer`. (Just one created on the dev site, needs special handling in the code).
* Then add some documents e.g `drush hr-docs-pop -v --limit=20` (offset is also an option, and we might need a way to bulk delete content too)

Some things to note:
* Still WIP, suggestions welcome
* Cache needs clearing on the docstore between runs, or the term and vocab query responses go stale.
* Only vocabulary references and one integer - doesn't include strings or dates yet (or files)
* Might stumble over very large vocabularies
* When creating an entity reference field (POST to document/fields with `"target":"machine_name"`), it creates a single value field. For now, this script just picks the first value.
* Checking the results in the docstore UI, the new fields are hidden by default in the form and display. This isn't really an issue, but it did trip me up (there was already a 'legacy_id' field for RW, and I got confused).
