### PR TITLE
[OPS-7230] update core to 7.78

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/dbtng_migrator": "^1.4",
         "drupal/defaultconfig": "^1.0-alpha11",
         "drupal/diff": "^3.4",
-        "drupal/drupal": "7.75",
+        "drupal/drupal": "^7.78",
         "drupal/elysia_cron": "^2.7",
         "drupal/email": "^1.3",
         "drupal/email_registration": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/dbtng_migrator": "^1.4",
         "drupal/defaultconfig": "^1.0-alpha11",
         "drupal/diff": "^3.4",
-        "drupal/drupal": "^7.78",
+        "drupal/drupal": "7.78",
         "drupal/elysia_cron": "^2.7",
         "drupal/email": "^1.3",
         "drupal/email_registration": "^1.4",
@@ -185,7 +185,10 @@
     "config": {
         "bin-dir": "bin/",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "platform": {
+          "php": "7.3.26"
+        }
     },
     "minimum-stability": "alpha",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ca5b1dc97677a9923e4dd73cf41e93d",
+    "content-hash": "648d794f1eb8d8a47455b383f627cec5",
     "packages": [
         {
             "name": "composer/installers",
@@ -12024,5 +12024,8 @@
         "php": ">= 7.3"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3.26"
+    },
     "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0f6277410d87e0725428b5468b429df",
+    "content-hash": "4ca5b1dc97677a9923e4dd73cf41e93d",
     "packages": [
         {
             "name": "composer/installers",
@@ -130,6 +130,16 @@
                 "yawik",
                 "zend",
                 "zikula"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-04-07T06:57:05+00:00"
         },
@@ -315,9 +325,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.3",
                     "datestamp": "1540579380",
@@ -376,9 +383,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1574192284",
@@ -462,10 +466,6 @@
                     "homepage": "https://www.drupal.org/user/1300542"
                 },
                 {
-                    "name": "markcarver",
-                    "homepage": "https://www.drupal.org/user/501638"
-                },
-                {
                     "name": "mikeytown2",
                     "homepage": "https://www.drupal.org/user/282446"
                 },
@@ -506,9 +506,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.4",
                     "datestamp": "1493219643",
@@ -534,6 +531,10 @@
                 {
                     "name": "bforchhammer",
                     "homepage": "https://www.drupal.org/user/216396"
+                },
+                {
+                    "name": "colan",
+                    "homepage": "https://www.drupal.org/user/58704"
                 },
                 {
                     "name": "diqidoq",
@@ -569,9 +570,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0",
                     "datestamp": "1566344885",
@@ -623,9 +621,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.13",
                     "datestamp": "1533832980",
@@ -647,10 +642,6 @@
                 {
                     "name": "arithmetric",
                     "homepage": "https://www.drupal.org/user/162305"
-                },
-                {
-                    "name": "brantwynn",
-                    "homepage": "https://www.drupal.org/user/252788"
                 },
                 {
                     "name": "fabsor",
@@ -675,6 +666,10 @@
                 {
                     "name": "rmontero",
                     "homepage": "https://www.drupal.org/user/191552"
+                },
+                {
+                    "name": "saltednut",
+                    "homepage": "https://www.drupal.org/user/252788"
                 },
                 {
                     "name": "skwashd",
@@ -717,9 +712,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.2",
                     "datestamp": "1469193839",
@@ -766,9 +758,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-beta9",
                     "datestamp": "1407772727",
@@ -786,6 +775,10 @@
                 {
                     "name": "hefox",
                     "homepage": "https://www.drupal.org/user/426416"
+                },
+                {
+                    "name": "joseph.olstad",
+                    "homepage": "https://www.drupal.org/user/1321830"
                 },
                 {
                     "name": "mcrittenden",
@@ -828,9 +821,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.5",
                     "datestamp": "1413299929",
@@ -850,20 +840,20 @@
                     "homepage": "https://www.drupal.org/user/45874"
                 },
                 {
+                    "name": "Neslee Canil Pinto",
+                    "homepage": "https://www.drupal.org/user/3580850"
+                },
+                {
                     "name": "fizk",
                     "homepage": "https://www.drupal.org/user/473174"
                 },
                 {
-                    "name": "geertvd",
-                    "homepage": "https://www.drupal.org/user/536694"
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
                 },
                 {
-                    "name": "pjonckiere",
-                    "homepage": "https://www.drupal.org/user/2442998"
-                },
-                {
-                    "name": "tedbow",
-                    "homepage": "https://www.drupal.org/user/240860"
+                    "name": "solide-echt",
+                    "homepage": "https://www.drupal.org/user/46176"
                 }
             ],
             "description": "Views plugin to display views containing dates as Calendars.",
@@ -891,9 +881,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.1",
                     "datestamp": "1490260383",
@@ -970,9 +957,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.9",
                     "datestamp": "1547651580",
@@ -1025,9 +1009,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.0-alpha2",
                     "datestamp": "1443545939",
@@ -1043,16 +1024,24 @@
             ],
             "authors": [
                 {
+                    "name": "Neslee Canil Pinto",
+                    "homepage": "https://www.drupal.org/user/3580850"
+                },
+                {
                     "name": "OlgaRabodzei",
                     "homepage": "https://www.drupal.org/user/3389198"
                 },
                 {
-                    "name": "axel.rutz",
-                    "homepage": "https://www.drupal.org/user/229048"
-                },
-                {
                     "name": "colan",
                     "homepage": "https://www.drupal.org/user/58704"
+                },
+                {
+                    "name": "ergonlogic",
+                    "homepage": "https://www.drupal.org/user/368613"
+                },
+                {
+                    "name": "geek-merlin",
+                    "homepage": "https://www.drupal.org/user/229048"
                 },
                 {
                     "name": "itsekhmistro",
@@ -1061,6 +1050,10 @@
                 {
                     "name": "peterpoe",
                     "homepage": "https://www.drupal.org/user/55674"
+                },
+                {
+                    "name": "thalles",
+                    "homepage": "https://www.drupal.org/user/3589086"
                 }
             ],
             "description": "Define dependencies between fields based on their states and values.",
@@ -1088,9 +1081,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-beta2",
                     "datestamp": "1361736156",
@@ -1156,9 +1146,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.10",
                     "datestamp": "1551291108",
@@ -1214,16 +1201,20 @@
                     "homepage": "https://www.drupal.org/user/426416"
                 },
                 {
-                    "name": "hyrcan",
-                    "homepage": "https://www.drupal.org/user/26618"
-                },
-                {
                     "name": "jmiccolis",
                     "homepage": "https://www.drupal.org/user/31731"
                 },
                 {
                     "name": "nedjo",
                     "homepage": "https://www.drupal.org/user/4481"
+                },
+                {
+                    "name": "patricksettle",
+                    "homepage": "https://www.drupal.org/user/26618"
+                },
+                {
+                    "name": "paulocs",
+                    "homepage": "https://www.drupal.org/user/3640109"
                 },
                 {
                     "name": "tekante",
@@ -1260,9 +1251,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.0",
                     "datestamp": "1349787369",
@@ -1303,13 +1291,14 @@
                 "shasum": "6000ada1e1ba9cf01d8e015e026b96c6fcf059ec"
             },
             "require": {
-                "drupal/drupal": "~7.0"
+                "drupal/context": "*",
+                "drupal/ctools": "*",
+                "drupal/drupal": "~7.0",
+                "drupal/og": "*",
+                "drupal/og_context": "*"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.1",
                     "datestamp": "1355739999",
@@ -1333,6 +1322,7 @@
                     "homepage": "https://www.drupal.org/user/20885"
                 }
             ],
+            "description": "Provides Organic Groups conditions and reactions for the Context module.",
             "homepage": "https://www.drupal.org/project/context_og",
             "support": {
                 "source": "https://git.drupalcode.org/project/context_og"
@@ -1422,9 +1412,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.15",
                     "datestamp": "1549603684",
@@ -1528,7 +1515,8 @@
                     }
                 },
                 "patches_applied": {
-                    "HR.info issue 913": "PATCHES/hrinfo-913.patch"
+                    "HR.info issue 913": "PATCHES/hrinfo-913.patch",
+                    "HR.info issue 1025": "PATCHES/hrinfo-1025.date-popup.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/7/downloads",
@@ -1686,9 +1674,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.9",
                     "datestamp": "1461609712",
@@ -1708,20 +1693,8 @@
                     "homepage": "https://www.drupal.org/user/1903688"
                 },
                 {
-                    "name": "Hadi Farnoud",
-                    "homepage": "https://www.drupal.org/user/38806"
-                },
-                {
-                    "name": "John Franklin",
-                    "homepage": "https://www.drupal.org/user/683430"
-                },
-                {
-                    "name": "axel.rutz",
-                    "homepage": "https://www.drupal.org/user/229048"
-                },
-                {
-                    "name": "coredumperror",
-                    "homepage": "https://www.drupal.org/user/1140544"
+                    "name": "joseph.olstad",
+                    "homepage": "https://www.drupal.org/user/1321830"
                 }
             ],
             "description": "Enables export of iCal feeds using Views, and import of iCal feeds using Feeds.",
@@ -1825,9 +1798,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.4",
                     "datestamp": "1382596227",
@@ -1877,9 +1847,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-alpha11",
                     "datestamp": "1443688139",
@@ -1932,9 +1899,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.4",
                     "datestamp": "1541401381",
@@ -1998,23 +1962,23 @@
         },
         {
             "name": "drupal/drupal",
-            "version": "7.75.0",
+            "version": "7.78.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/drupal.git",
-                "reference": "7.75"
+                "reference": "7.78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/drupal-7.75.zip",
-                "reference": "7.75",
-                "shasum": "cd1eaee1b26acd53824c5d42d1bc93d64af026f2"
+                "url": "https://ftp.drupal.org/files/projects/drupal-7.78.zip",
+                "reference": "7.78",
+                "shasum": "1358a9b8022877fc692b62eb19d7efb0d3f85ee4"
             },
             "type": "drupal-core",
             "extra": {
                 "drupal": {
-                    "version": "7.75",
-                    "datestamp": "1606361101",
+                    "version": "7.78",
+                    "datestamp": "1611163112",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2176,9 +2140,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.3",
                     "datestamp": "1397134152",
@@ -2283,9 +2244,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.9",
                     "datestamp": "1518642010",
@@ -2319,6 +2277,10 @@
                 {
                     "name": "fago",
                     "homepage": "https://www.drupal.org/user/16747"
+                },
+                {
+                    "name": "mglaman",
+                    "homepage": "https://www.drupal.org/user/2416470"
                 }
             ],
             "description": "Enables modules to work with any entity type and to provide entities.",
@@ -2461,13 +2423,10 @@
                 "shasum": "ae6ec0739e5a3fbacabb54e05f08864b6e06a2b0"
             },
             "require": {
-                "drupal/drupal": "~7.0"
+                "drupal/drupal": "^7.36"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.5",
                     "datestamp": "1446719510",
@@ -2499,6 +2458,7 @@
                     "homepage": "https://www.drupal.org/user/116305"
                 }
             ],
+            "description": "Provides caching for core entities including nodes and taxonomy terms.",
             "homepage": "https://www.drupal.org/project/entitycache",
             "support": {
                 "source": "https://git.drupalcode.org/project/entitycache"
@@ -2529,9 +2489,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.5",
                     "datestamp": "1502906584",
@@ -2601,9 +2558,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.13",
                     "datestamp": "1490279584",
@@ -2654,9 +2608,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1471604814",
@@ -2671,6 +2622,10 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
+                {
+                    "name": "maximkashuba",
+                    "homepage": "https://www.drupal.org/user/2463262"
+                },
                 {
                     "name": "maximpodorov",
                     "homepage": "https://www.drupal.org/user/515310"
@@ -2702,9 +2657,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1485445388",
@@ -2754,9 +2706,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.9",
                     "datestamp": "1510267684",
@@ -2778,6 +2727,10 @@
                 {
                     "name": "mrfelton",
                     "homepage": "https://www.drupal.org/user/305669"
+                },
+                {
+                    "name": "pratik_kamble",
+                    "homepage": "https://www.drupal.org/user/3204909"
                 }
             ],
             "description": "Adds a color indicator for the different environments.",
@@ -2959,9 +2912,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-beta2",
                     "datestamp": "1327885860",
@@ -3007,9 +2957,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.4",
                     "datestamp": "1427560981",
@@ -3066,9 +3013,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.11",
                     "datestamp": "1541189192",
@@ -3098,6 +3042,10 @@
                 {
                     "name": "febbraro",
                     "homepage": "https://www.drupal.org/user/43670"
+                },
+                {
+                    "name": "flocondetoile",
+                    "homepage": "https://www.drupal.org/user/2006064"
                 },
                 {
                     "name": "jmiccolis",
@@ -3316,9 +3264,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.2",
                     "datestamp": "1512894785",
@@ -3447,9 +3392,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.1",
                     "datestamp": "1354726970",
@@ -3576,9 +3518,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.6",
                     "datestamp": "1434802380",
@@ -3640,9 +3579,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.13",
                     "datestamp": "1552402084",
@@ -3707,9 +3643,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.12",
                     "datestamp": "1446333839",
@@ -3883,9 +3816,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.9",
                     "datestamp": "1474619039",
@@ -3900,6 +3830,10 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
                 {
                     "name": "fago",
                     "homepage": "https://www.drupal.org/user/16747"
@@ -3963,9 +3897,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.2",
                     "datestamp": "1423733881",
@@ -4062,9 +3993,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.4",
                     "datestamp": "1540417981",
@@ -4137,9 +4065,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1352084822",
@@ -4157,6 +4082,10 @@
                 {
                     "name": "Brandonian",
                     "homepage": "https://www.drupal.org/user/77766"
+                },
+                {
+                    "name": "Neslee Canil Pinto",
+                    "homepage": "https://www.drupal.org/user/3580850"
                 },
                 {
                     "name": "phayes",
@@ -4195,9 +4124,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.6",
                     "datestamp": "1548968580",
@@ -4213,12 +4139,28 @@
             ],
             "authors": [
                 {
+                    "name": "andyrigby",
+                    "homepage": "https://www.drupal.org/user/2679687"
+                },
+                {
                     "name": "budda",
                     "homepage": "https://www.drupal.org/user/13164"
                 },
                 {
-                    "name": "hass",
-                    "homepage": "https://www.drupal.org/user/85918"
+                    "name": "ixismark",
+                    "homepage": "https://www.drupal.org/user/3632333"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "pfaocle",
+                    "homepage": "https://www.drupal.org/user/9740"
+                },
+                {
+                    "name": "roberto.rivera.ixis",
+                    "homepage": "https://www.drupal.org/user/3632325"
                 }
             ],
             "homepage": "https://www.drupal.org/project/google_analytics",
@@ -4298,9 +4240,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.16",
                     "datestamp": "1531318398",
@@ -4621,9 +4560,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.16",
                     "datestamp": "1438457939",
@@ -4680,9 +4616,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0",
                     "datestamp": "1362244512",
@@ -4852,9 +4785,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.0",
                     "datestamp": "1518514084",
@@ -4935,9 +4865,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.7",
                     "datestamp": "1445458536",
@@ -4971,10 +4898,6 @@
                 {
                     "name": "markcarver",
                     "homepage": "https://www.drupal.org/user/501638"
-                },
-                {
-                    "name": "mfer",
-                    "homepage": "https://www.drupal.org/user/25701"
                 },
                 {
                     "name": "sun",
@@ -5114,9 +5037,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1507136644",
@@ -5165,12 +5085,9 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.5",
-                    "datestamp": "1538770681",
+                    "datestamp": "1569052574",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5316,9 +5233,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.4",
                     "datestamp": "1534714680",
@@ -5333,6 +5247,10 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
+                {
+                    "name": "C_Logemann",
+                    "homepage": "https://www.drupal.org/user/218368"
+                },
                 {
                     "name": "hass",
                     "homepage": "https://www.drupal.org/user/85918"
@@ -5365,9 +5283,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.5",
                     "datestamp": "1452407339",
@@ -5412,9 +5327,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.1",
                     "datestamp": "1425773217",
@@ -5467,9 +5379,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-rc7",
                     "datestamp": "1394333605",
@@ -5543,9 +5452,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.19",
                     "datestamp": "1534544281",
@@ -5628,13 +5534,10 @@
             "version": "2.19.0",
             "require": {
                 "drupal/drupal": "~7.0",
-                "drupal/media": "self.version"
+                "drupal/media": "*"
             },
             "type": "metapackage",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.19",
                     "datestamp": "1534544281",
@@ -5732,9 +5635,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.1",
                     "datestamp": "1432838581",
@@ -5807,9 +5707,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.9",
                     "datestamp": "1570113186",
@@ -5887,6 +5784,10 @@
                 {
                     "name": "pwolanin",
                     "homepage": "https://www.drupal.org/user/49851"
+                },
+                {
+                    "name": "solideogloria",
+                    "homepage": "https://www.drupal.org/user/3589277"
                 },
                 {
                     "name": "steinmb",
@@ -5990,9 +5891,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1516182785",
@@ -6045,9 +5943,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.11",
                     "datestamp": "1530180224",
@@ -6097,9 +5992,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.0",
                     "datestamp": "1437901739",
@@ -6144,9 +6036,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0",
                     "datestamp": "1447900440",
@@ -6190,12 +6079,9 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.7",
-                    "datestamp": "1497976586",
+                    "datestamp": "1582667821",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6216,7 +6102,7 @@
                     "homepage": "https://www.drupal.org/user/1962106"
                 },
                 {
-                    "name": "diosbelmezquia",
+                    "name": "dmezquia",
                     "homepage": "https://www.drupal.org/user/3334752"
                 },
                 {
@@ -6263,9 +6149,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.10",
                     "datestamp": "1530174224",
@@ -6311,6 +6194,10 @@
                 {
                     "name": "dww",
                     "homepage": "https://www.drupal.org/user/46549"
+                },
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
                 },
                 {
                     "name": "merlinofchaos",
@@ -6442,9 +6329,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.0-beta4",
                     "datestamp": "1396962551",
@@ -6495,9 +6379,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.2",
                     "datestamp": "1563951785",
@@ -6563,9 +6444,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.3",
                     "datestamp": "1396518246",
@@ -6615,9 +6493,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-beta2",
                     "datestamp": "1383055290",
@@ -6749,9 +6624,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0",
                     "datestamp": "1436385539",
@@ -6810,9 +6682,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.0-beta11",
                     "datestamp": "1413561921",
@@ -6861,14 +6730,11 @@
             "name": "drupal/page_manager",
             "version": "1.15.0",
             "require": {
-                "drupal/ctools": "self.version",
+                "drupal/ctools": "*",
                 "drupal/drupal": "~7.0"
             },
             "type": "metapackage",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.15",
                     "datestamp": "1549603684",
@@ -6962,9 +6828,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.4",
                     "datestamp": "1471635539",
@@ -7124,9 +6987,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.0",
                     "datestamp": "1398607727",
@@ -7281,15 +7141,12 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-rc4",
                     "datestamp": "1364285423",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "message": "RC releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -7301,6 +7158,14 @@
                 {
                     "name": "gabrielu",
                     "homepage": "https://www.drupal.org/user/279352"
+                },
+                {
+                    "name": "kporras07",
+                    "homepage": "https://www.drupal.org/user/1349780"
+                },
+                {
+                    "name": "otrolopezmas",
+                    "homepage": "https://www.drupal.org/user/3516204"
                 },
                 {
                     "name": "plopesc",
@@ -7337,9 +7202,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.3",
                     "datestamp": "1444232639",
@@ -7397,9 +7259,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.1",
                     "datestamp": "1335210084",
@@ -7515,9 +7374,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.1",
                     "datestamp": "1454848139",
@@ -7570,9 +7426,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.3",
                     "datestamp": "1474067039",
@@ -7682,9 +7535,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.2",
                     "datestamp": "1363209312",
@@ -7733,9 +7583,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.4",
                     "datestamp": "1467708539",
@@ -7769,6 +7616,10 @@
                 {
                     "name": "malaussene",
                     "homepage": "https://www.drupal.org/user/79249"
+                },
+                {
+                    "name": "rodrigoaguilera",
+                    "homepage": "https://www.drupal.org/user/408170"
                 }
             ],
             "description": "Adds a 'Publish' or 'Unpublish' link on the node edit/view pages, and a 'Publish Link' field if the Views module is enabled.",
@@ -7845,9 +7696,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.4",
                     "datestamp": "1433951880",
@@ -7900,9 +7748,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.4",
                     "datestamp": "1548970380",
@@ -7975,9 +7820,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-rc3",
                     "datestamp": "1436393339",
@@ -8030,9 +7872,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.18",
                     "datestamp": "1572430084",
@@ -8086,9 +7925,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0",
                     "datestamp": "1411816455",
@@ -8133,9 +7969,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.3",
                     "datestamp": "1441286339",
@@ -8180,9 +8013,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.0",
                     "datestamp": "1474305839",
@@ -8245,9 +8075,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.17",
                     "datestamp": "1553101123",
@@ -8303,9 +8130,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0",
                     "datestamp": "1327037146",
@@ -8363,9 +8187,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.12",
                     "datestamp": "1548305581",
@@ -8423,9 +8244,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.26",
                     "datestamp": "1552334580",
@@ -8482,9 +8300,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1537174685",
@@ -8595,9 +8410,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0",
                     "datestamp": "1497319146",
@@ -8654,9 +8466,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1487181167",
@@ -8752,9 +8561,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1514932985",
@@ -8799,9 +8605,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.8",
                     "datestamp": "1552503450",
@@ -8820,6 +8623,10 @@
                 "GPL-2.0-or-later"
             ],
             "authors": [
+                {
+                    "name": "jhedstrom",
+                    "homepage": "https://www.drupal.org/user/208732"
+                },
                 {
                     "name": "stBorchert",
                     "homepage": "https://www.drupal.org/user/36942"
@@ -8853,9 +8660,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1498667346",
@@ -8885,6 +8689,10 @@
                 {
                     "name": "oadaeh",
                     "homepage": "https://www.drupal.org/user/4649"
+                },
+                {
+                    "name": "sadashiv",
+                    "homepage": "https://www.drupal.org/user/1773304"
                 },
                 {
                     "name": "wundo",
@@ -8920,9 +8728,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.1",
                     "datestamp": "1563457686",
@@ -8988,9 +8793,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.0",
                     "datestamp": "1339604214",
@@ -9055,9 +8857,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.2",
                     "datestamp": "1457713741",
@@ -9110,9 +8909,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.4",
                     "datestamp": "1490837285",
@@ -9249,9 +9045,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1485316084",
@@ -9317,9 +9110,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.1",
                     "datestamp": "1325700944",
@@ -9431,9 +9221,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.2",
                     "datestamp": "1395079431",
@@ -9533,9 +9320,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.11",
                     "datestamp": "1439807339",
@@ -9557,6 +9341,10 @@
                 {
                     "name": "ZenDoodles",
                     "homepage": "https://www.drupal.org/user/226976"
+                },
+                {
+                    "name": "alorenc",
+                    "homepage": "https://www.drupal.org/user/3603980"
                 },
                 {
                     "name": "antiorario",
@@ -9600,9 +9388,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.5",
                     "datestamp": "1398250127",
@@ -9781,9 +9566,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.9",
                     "datestamp": "1532082181",
@@ -9987,13 +9769,12 @@
                 "shasum": "0228742d4f96e626207473de08433ad0e98b4d2a"
             },
             "require": {
-                "drupal/drupal": "~7.0"
+                "drupal/ctools": "*",
+                "drupal/drupal": "~7.0",
+                "drupal/views": "*"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.0-alpha3",
                     "datestamp": "1383658105",
@@ -10013,6 +9794,7 @@
                     "homepage": "https://www.drupal.org/user/99644"
                 }
             ],
+            "description": "Provides a views cache plugin based on content type changes.",
             "homepage": "https://www.drupal.org/project/views_content_cache",
             "support": {
                 "source": "https://git.drupalcode.org/project/views_content_cache"
@@ -10038,9 +9820,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-3.2",
                     "datestamp": "1491379384",
@@ -10107,9 +9886,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-beta3",
                     "datestamp": "1451575439",
@@ -10168,9 +9944,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.7",
                     "datestamp": "1484920083",
@@ -10186,12 +9959,12 @@
             ],
             "authors": [
                 {
-                    "name": "killua99",
-                    "homepage": "https://www.drupal.org/user/699418"
+                    "name": "RickJ",
+                    "homepage": "https://www.drupal.org/user/3371606"
                 },
                 {
-                    "name": "vegansupreme",
-                    "homepage": "https://www.drupal.org/user/674852"
+                    "name": "killua99",
+                    "homepage": "https://www.drupal.org/user/699418"
                 }
             ],
             "description": "Views plugin to export a view as a PDF file.",
@@ -10220,9 +9993,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.1",
                     "datestamp": "1431972781",
@@ -10268,9 +10038,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.0-rc4",
                     "datestamp": "1419363780",
@@ -10304,6 +10071,10 @@
                 {
                     "name": "alex_b",
                     "homepage": "https://www.drupal.org/user/53995"
+                },
+                {
+                    "name": "idebr",
+                    "homepage": "https://www.drupal.org/user/1879760"
                 },
                 {
                     "name": "maciej.zgadzaj",
@@ -10340,9 +10111,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.0-beta2",
                     "datestamp": "1439073239",
@@ -10399,12 +10167,9 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-2.6",
-                    "datestamp": "1563397062",
+                    "datestamp": "1563520137",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -10450,9 +10215,6 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
                     "version": "7.x-1.6-rc9",
                     "datestamp": "1508857145",
@@ -10468,7 +10230,7 @@
             ],
             "authors": [
                 {
-                    "name": "axel.rutz",
+                    "name": "geek-merlin",
                     "homepage": "https://www.drupal.org/user/229048"
                 },
                 {
@@ -10621,6 +10383,20 @@
             "keywords": [
                 "Xdebug",
                 "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-04T11:16:35+00:00"
         },
@@ -11240,6 +11016,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-23T13:08:13+00:00"
         },
         {
@@ -11317,6 +11107,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T20:06:45+00:00"
         },
         {
@@ -11392,6 +11196,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-12T08:11:32+00:00"
         },
         {
@@ -11438,6 +11256,20 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-27T08:34:37+00:00"
         },
         {
@@ -11488,6 +11320,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T18:50:54+00:00"
         },
         {
@@ -11537,6 +11383,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -11598,6 +11458,20 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-06T08:46:27+00:00"
         },
@@ -11662,6 +11536,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -11723,6 +11611,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-06T08:46:27+00:00"
         },
@@ -11790,6 +11692,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -11847,6 +11763,20 @@
                 "interfaces",
                 "interoperability",
                 "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-20T17:43:50+00:00"
         },
@@ -11911,6 +11841,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -11958,12 +11902,12 @@
             "version": "1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
                 "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
                 "shasum": ""
             },

--- a/html/CHANGELOG.txt
+++ b/html/CHANGELOG.txt
@@ -1,3 +1,18 @@
+Drupal 7.78, 2021-01-19
+-----------------------
+- Fixed security issues:
+   - SA-CORE-2021-001
+
+Drupal 7.77, 2020-12-03
+-----------------------
+- Hotfix for schema.prefixed tables
+
+Drupal 7.76, 2020-12-02
+-----------------------
+- Support for MySQL 8
+- Core tests pass in SQLite
+- Better user flood control logging
+
 Drupal 7.75, 2020-11-26
 -----------------------
 - Fixed security issues:

--- a/html/MAINTAINERS.txt
+++ b/html/MAINTAINERS.txt
@@ -12,7 +12,7 @@ The branch maintainers for Drupal 7 are:
 
 - Dries Buytaert 'dries' https://www.drupal.org/u/dries
 - Fabian Franz 'Fabianx' https://www.drupal.org/u/fabianx
-- (provisional) Drew Webber 'mcdruid' https://www.drupal.org/u/mcdruid
+- Drew Webber 'mcdruid' https://www.drupal.org/u/mcdruid
 
 
 Component maintainers

--- a/html/includes/bootstrap.inc
+++ b/html/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.75');
+define('VERSION', '7.78');
 
 /**
  * Core API compatibility.
@@ -1189,19 +1189,21 @@ function variable_initialize($conf = array()) {
     $variables = $cached->data;
   }
   else {
-    // Cache miss. Avoid a stampede.
+    // Cache miss. Avoid a stampede by acquiring a lock. If the lock fails to
+    // acquire, optionally just continue with uncached processing.
     $name = 'variable_init';
-    if (!lock_acquire($name, 1)) {
-      // Another request is building the variable cache.
-      // Wait, then re-run this function.
+    $lock_acquired = lock_acquire($name, 1);
+    if (!$lock_acquired && variable_get('variable_initialize_wait_for_lock', FALSE)) {
       lock_wait($name);
       return variable_initialize($conf);
     }
     else {
-      // Proceed with variable rebuild.
+      // Load the variables from the table.
       $variables = array_map('unserialize', db_query('SELECT name, value FROM {variable}')->fetchAllKeyed());
-      cache_set('variables', $variables, 'cache_bootstrap');
-      lock_release($name);
+      if ($lock_acquired) {
+        cache_set('variables', $variables, 'cache_bootstrap');
+        lock_release($name);
+      }
     }
   }
 

--- a/html/includes/common.inc
+++ b/html/includes/common.inc
@@ -2329,6 +2329,7 @@ function url($path = NULL, array $options = array()) {
   }
   elseif (!empty($path) && !$options['alias']) {
     $language = isset($options['language']) && isset($options['language']->language) ? $options['language']->language : '';
+    require_once DRUPAL_ROOT . '/' . variable_get('path_inc', 'includes/path.inc');
     $alias = drupal_get_path_alias($original_path, $language);
     if ($alias != $original_path) {
       // Strip leading slashes from internal path aliases to prevent them

--- a/html/includes/common.inc
+++ b/html/includes/common.inc
@@ -2329,7 +2329,6 @@ function url($path = NULL, array $options = array()) {
   }
   elseif (!empty($path) && !$options['alias']) {
     $language = isset($options['language']) && isset($options['language']->language) ? $options['language']->language : '';
-    require_once DRUPAL_ROOT . '/' . variable_get('path_inc', 'includes/path.inc');
     $alias = drupal_get_path_alias($original_path, $language);
     if ($alias != $original_path) {
       // Strip leading slashes from internal path aliases to prevent them
@@ -6654,30 +6653,41 @@ function element_children(&$elements, $sort = FALSE) {
   $sort = isset($elements['#sorted']) ? !$elements['#sorted'] : $sort;
 
   // Filter out properties from the element, leaving only children.
-  $children = array();
+  $count = count($elements);
+  $child_weights = array();
+  $i = 0;
   $sortable = FALSE;
   foreach ($elements as $key => $value) {
     if (is_int($key) || $key === '' || $key[0] !== '#') {
-      $children[$key] = $value;
       if (is_array($value) && isset($value['#weight'])) {
+        $weight = $value['#weight'];
         $sortable = TRUE;
       }
+      else {
+        $weight = 0;
+      }
+      // Support weights with up to three digit precision and conserve the
+      // insertion order.
+      $child_weights[$key] = floor($weight * 1000) + $i / $count;
     }
+    $i++;
   }
+
   // Sort the children if necessary.
   if ($sort && $sortable) {
-    uasort($children, 'element_sort');
+    asort($child_weights);
     // Put the sorted children back into $elements in the correct order, to
     // preserve sorting if the same element is passed through
     // element_children() twice.
-    foreach ($children as $key => $child) {
+    foreach ($child_weights as $key => $weight) {
+      $value = $elements[$key];
       unset($elements[$key]);
-      $elements[$key] = $child;
+      $elements[$key] = $value;
     }
     $elements['#sorted'] = TRUE;
   }
 
-  return array_keys($children);
+  return array_keys($child_weights);
 }
 
 /**

--- a/html/includes/database/database.inc
+++ b/html/includes/database/database.inc
@@ -310,6 +310,13 @@ abstract class DatabaseConnection extends PDO {
    */
   protected $escapedAliases = array();
 
+  /**
+   * List of un-prefixed table names, keyed by prefixed table names.
+   *
+   * @var array
+   */
+  protected $unprefixedTablesMap = array();
+
   function __construct($dsn, $username, $password, $driver_options = array()) {
     // Initialize and prepare the connection prefix.
     $this->setPrefix(isset($this->connectionOptions['prefix']) ? $this->connectionOptions['prefix'] : '');
@@ -338,7 +345,9 @@ abstract class DatabaseConnection extends PDO {
     // Destroy all references to this connection by setting them to NULL.
     // The Statement class attribute only accepts a new value that presents a
     // proper callable, so we reset it to PDOStatement.
-    $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('PDOStatement', array()));
+    if (!empty($this->statementClass)) {
+      $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('PDOStatement', array()));
+    }
     $this->schema = NULL;
   }
 
@@ -442,6 +451,13 @@ abstract class DatabaseConnection extends PDO {
     $this->prefixReplace[] = $this->prefixes['default'];
     $this->prefixSearch[] = '}';
     $this->prefixReplace[] = '';
+
+    // Set up a map of prefixed => un-prefixed tables.
+    foreach ($this->prefixes as $table_name => $prefix) {
+      if ($table_name !== 'default') {
+        $this->unprefixedTablesMap[$prefix . $table_name] = $table_name;
+      }
+    }
   }
 
   /**
@@ -475,6 +491,17 @@ abstract class DatabaseConnection extends PDO {
     else {
       return $this->prefixes['default'];
     }
+  }
+
+  /**
+   * Gets a list of individually prefixed table names.
+   *
+   * @return array
+   *   An array of un-prefixed table names, keyed by their fully qualified table
+   *   names (i.e. prefix + table_name).
+   */
+  public function getUnprefixedTablesMap() {
+    return $this->unprefixedTablesMap;
   }
 
   /**
@@ -2840,13 +2867,29 @@ function db_field_exists($table, $field) {
  *
  * @param $table_expression
  *   An SQL expression, for example "simpletest%" (without the quotes).
- *   BEWARE: this is not prefixed, the caller should take care of that.
  *
  * @return
  *   Array, both the keys and the values are the matching tables.
  */
 function db_find_tables($table_expression) {
   return Database::getConnection()->schema()->findTables($table_expression);
+}
+
+/**
+ * Finds all tables that are like the specified base table name. This is a
+ * backport of the change made to db_find_tables in Drupal 8 to work with
+ * virtual, un-prefixed table names. The original function is retained for
+ * Backwards Compatibility.
+ * @see https://www.drupal.org/node/2552435
+ *
+ * @param $table_expression
+ *   An SQL expression, for example "simpletest%" (without the quotes).
+ *
+ * @return
+ *   Array, both the keys and the values are the matching tables.
+ */
+function db_find_tables_d8($table_expression) {
+  return Database::getConnection()->schema()->findTablesD8($table_expression);
 }
 
 function _db_create_keys_sql($spec) {

--- a/html/includes/database/mysql/database.inc
+++ b/html/includes/database/mysql/database.inc
@@ -6,6 +6,11 @@
  */
 
 /**
+ * The default character for quoting identifiers in MySQL.
+ */
+define('MYSQL_IDENTIFIER_QUOTE_CHARACTER_DEFAULT', '`');
+
+/**
  * @addtogroup database
  * @{
  */
@@ -18,6 +23,277 @@ class DatabaseConnection_mysql extends DatabaseConnection {
    * @var boolean
    */
   protected $needsCleanup = FALSE;
+
+  /**
+   * The list of MySQL reserved key words.
+   *
+   * @link https://dev.mysql.com/doc/refman/8.0/en/keywords.html
+   */
+  private $reservedKeyWords = array(
+    'accessible',
+    'add',
+    'admin',
+    'all',
+    'alter',
+    'analyze',
+    'and',
+    'as',
+    'asc',
+    'asensitive',
+    'before',
+    'between',
+    'bigint',
+    'binary',
+    'blob',
+    'both',
+    'by',
+    'call',
+    'cascade',
+    'case',
+    'change',
+    'char',
+    'character',
+    'check',
+    'collate',
+    'column',
+    'condition',
+    'constraint',
+    'continue',
+    'convert',
+    'create',
+    'cross',
+    'cube',
+    'cume_dist',
+    'current_date',
+    'current_time',
+    'current_timestamp',
+    'current_user',
+    'cursor',
+    'database',
+    'databases',
+    'day_hour',
+    'day_microsecond',
+    'day_minute',
+    'day_second',
+    'dec',
+    'decimal',
+    'declare',
+    'default',
+    'delayed',
+    'delete',
+    'dense_rank',
+    'desc',
+    'describe',
+    'deterministic',
+    'distinct',
+    'distinctrow',
+    'div',
+    'double',
+    'drop',
+    'dual',
+    'each',
+    'else',
+    'elseif',
+    'empty',
+    'enclosed',
+    'escaped',
+    'except',
+    'exists',
+    'exit',
+    'explain',
+    'false',
+    'fetch',
+    'first_value',
+    'float',
+    'float4',
+    'float8',
+    'for',
+    'force',
+    'foreign',
+    'from',
+    'fulltext',
+    'function',
+    'generated',
+    'get',
+    'grant',
+    'group',
+    'grouping',
+    'groups',
+    'having',
+    'high_priority',
+    'hour_microsecond',
+    'hour_minute',
+    'hour_second',
+    'if',
+    'ignore',
+    'in',
+    'index',
+    'infile',
+    'inner',
+    'inout',
+    'insensitive',
+    'insert',
+    'int',
+    'int1',
+    'int2',
+    'int3',
+    'int4',
+    'int8',
+    'integer',
+    'interval',
+    'into',
+    'io_after_gtids',
+    'io_before_gtids',
+    'is',
+    'iterate',
+    'join',
+    'json_table',
+    'key',
+    'keys',
+    'kill',
+    'lag',
+    'last_value',
+    'lead',
+    'leading',
+    'leave',
+    'left',
+    'like',
+    'limit',
+    'linear',
+    'lines',
+    'load',
+    'localtime',
+    'localtimestamp',
+    'lock',
+    'long',
+    'longblob',
+    'longtext',
+    'loop',
+    'low_priority',
+    'master_bind',
+    'master_ssl_verify_server_cert',
+    'match',
+    'maxvalue',
+    'mediumblob',
+    'mediumint',
+    'mediumtext',
+    'middleint',
+    'minute_microsecond',
+    'minute_second',
+    'mod',
+    'modifies',
+    'natural',
+    'not',
+    'no_write_to_binlog',
+    'nth_value',
+    'ntile',
+    'null',
+    'numeric',
+    'of',
+    'on',
+    'optimize',
+    'optimizer_costs',
+    'option',
+    'optionally',
+    'or',
+    'order',
+    'out',
+    'outer',
+    'outfile',
+    'over',
+    'partition',
+    'percent_rank',
+    'persist',
+    'persist_only',
+    'precision',
+    'primary',
+    'procedure',
+    'purge',
+    'range',
+    'rank',
+    'read',
+    'reads',
+    'read_write',
+    'real',
+    'recursive',
+    'references',
+    'regexp',
+    'release',
+    'rename',
+    'repeat',
+    'replace',
+    'require',
+    'resignal',
+    'restrict',
+    'return',
+    'revoke',
+    'right',
+    'rlike',
+    'row',
+    'rows',
+    'row_number',
+    'schema',
+    'schemas',
+    'second_microsecond',
+    'select',
+    'sensitive',
+    'separator',
+    'set',
+    'show',
+    'signal',
+    'smallint',
+    'spatial',
+    'specific',
+    'sql',
+    'sqlexception',
+    'sqlstate',
+    'sqlwarning',
+    'sql_big_result',
+    'sql_calc_found_rows',
+    'sql_small_result',
+    'ssl',
+    'starting',
+    'stored',
+    'straight_join',
+    'system',
+    'table',
+    'terminated',
+    'then',
+    'tinyblob',
+    'tinyint',
+    'tinytext',
+    'to',
+    'trailing',
+    'trigger',
+    'true',
+    'undo',
+    'union',
+    'unique',
+    'unlock',
+    'unsigned',
+    'update',
+    'usage',
+    'use',
+    'using',
+    'utc_date',
+    'utc_time',
+    'utc_timestamp',
+    'values',
+    'varbinary',
+    'varchar',
+    'varcharacter',
+    'varying',
+    'virtual',
+    'when',
+    'where',
+    'while',
+    'window',
+    'with',
+    'write',
+    'xor',
+    'year_month',
+    'zerofill',
+  );
 
   public function __construct(array $connection_options = array()) {
     // This driver defaults to transaction support, except if explicitly passed FALSE.
@@ -86,13 +362,93 @@ class DatabaseConnection_mysql extends DatabaseConnection {
     $connection_options += array(
       'init_commands' => array(),
     );
+
+    $sql_mode = 'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO';
+    // NO_AUTO_CREATE_USER was removed in MySQL 8.0.11
+    // https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-11.html#mysqld-8-0-11-deprecation-removal
+    if (version_compare($this->getAttribute(PDO::ATTR_SERVER_VERSION), '8.0.11', '<')) {
+      $sql_mode .= ',NO_AUTO_CREATE_USER';
+    }
     $connection_options['init_commands'] += array(
-      'sql_mode' => "SET sql_mode = 'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER'",
+      'sql_mode' => "SET sql_mode = '$sql_mode'",
     );
+
     // Execute initial commands.
     foreach ($connection_options['init_commands'] as $sql) {
       $this->exec($sql);
     }
+  }
+
+  /**
+   * {@inheritdoc}}
+   */
+  protected function setPrefix($prefix) {
+    parent::setPrefix($prefix);
+    // Successive versions of MySQL have become increasingly strict about the
+    // use of reserved keywords as table names. Drupal 7 uses at least one such
+    // table (system). Therefore we surround all table names with quotes.
+    $quote_char = variable_get('mysql_identifier_quote_character', MYSQL_IDENTIFIER_QUOTE_CHARACTER_DEFAULT);
+    foreach ($this->prefixSearch as $i => $prefixSearch) {
+      if (substr($prefixSearch, 0, 1) === '{') {
+        // If the prefix already contains one or more quotes remove them.
+        // This can happen when - for example - DrupalUnitTestCase sets up a
+        // "temporary prefixed database". Also if there's a dot in the prefix,
+        // wrap it in quotes to cater for schema names in prefixes.
+        $search = array($quote_char, '.');
+        $replace = array('', $quote_char . '.' . $quote_char);
+        $this->prefixReplace[$i] = $quote_char . str_replace($search, $replace, $this->prefixReplace[$i]);
+      }
+      if (substr($prefixSearch, -1) === '}') {
+        $this->prefixReplace[$i] .= $quote_char;
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function escapeField($field) {
+    $field = parent::escapeField($field);
+    return $this->quoteIdentifier($field);
+  }
+
+  public function escapeFields(array $fields) {
+    foreach ($fields as &$field) {
+      $field = $this->escapeField($field);
+    }
+    return $fields;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function escapeAlias($field) {
+    $field = parent::escapeAlias($field);
+    return $this->quoteIdentifier($field);
+  }
+
+  /**
+   * Quotes an identifier if it matches a MySQL reserved keyword.
+   *
+   * @param string $identifier
+   *   The field to check.
+   *
+   * @return string
+   *   The identifier, quoted if it matches a MySQL reserved keyword.
+   */
+  private function quoteIdentifier($identifier) {
+    // Quote identifiers so that MySQL reserved words like 'function' can be
+    // used as column names. Sometimes the 'table.column_name' format is passed
+    // in. For example, menu_load_links() adds a condition on "ml.menu_name".
+    if (strpos($identifier, '.') !== FALSE) {
+      list($table, $identifier) = explode('.', $identifier, 2);
+    }
+    if (in_array(strtolower($identifier), $this->reservedKeyWords, TRUE)) {
+      // Quote the string for MySQL reserved keywords.
+      $quote_char = variable_get('mysql_identifier_quote_character', MYSQL_IDENTIFIER_QUOTE_CHARACTER_DEFAULT);
+      $identifier = $quote_char . $identifier . $quote_char;
+    }
+    return isset($table) ? $table . '.' . $identifier : $identifier;
   }
 
   public function __destruct() {

--- a/html/includes/database/mysql/query.inc
+++ b/html/includes/database/mysql/query.inc
@@ -48,6 +48,10 @@ class InsertQuery_mysql extends InsertQuery {
     // Default fields are always placed first for consistency.
     $insert_fields = array_merge($this->defaultFields, $this->insertFields);
 
+    if (method_exists($this->connection, 'escapeFields')) {
+      $insert_fields = $this->connection->escapeFields($insert_fields);
+    }
+
     // If we're selecting from a SelectQuery, finish building the query and
     // pass it back, as any remaining options are irrelevant.
     if (!empty($this->fromQuery)) {
@@ -88,6 +92,20 @@ class InsertQuery_mysql extends InsertQuery {
 }
 
 class TruncateQuery_mysql extends TruncateQuery { }
+
+class UpdateQuery_mysql extends UpdateQuery {
+  public function __toString() {
+    if (method_exists($this->connection, 'escapeField')) {
+      $escapedFields = array();
+      foreach ($this->fields as $field => $data) {
+        $field = $this->connection->escapeField($field);
+        $escapedFields[$field] = $data;
+      }
+      $this->fields = $escapedFields;
+    }
+    return parent::__toString();
+  }
+}
 
 /**
  * @} End of "addtogroup database".

--- a/html/includes/database/mysql/schema.inc
+++ b/html/includes/database/mysql/schema.inc
@@ -57,6 +57,11 @@ class DatabaseSchema_mysql extends DatabaseSchema {
   protected function buildTableNameCondition($table_name, $operator = '=', $add_prefix = TRUE) {
     $info = $this->connection->getConnectionOptions();
 
+    // Ensure the table name is not surrounded with quotes as that is not
+    // appropriate for schema queries.
+    $quote_char = variable_get('mysql_identifier_quote_character', MYSQL_IDENTIFIER_QUOTE_CHARACTER_DEFAULT);
+    $table_name = str_replace($quote_char, '', $table_name);
+
     $table_info = $this->getPrefixInfo($table_name, $add_prefix);
 
     $condition = new DatabaseCondition('AND');
@@ -494,11 +499,11 @@ class DatabaseSchema_mysql extends DatabaseSchema {
       $condition->condition('column_name', $column);
       $condition->compile($this->connection, $this);
       // Don't use {} around information_schema.columns table.
-      return $this->connection->query("SELECT column_comment FROM information_schema.columns WHERE " . (string) $condition, $condition->arguments())->fetchField();
+      return $this->connection->query("SELECT column_comment AS column_comment FROM information_schema.columns WHERE " . (string) $condition, $condition->arguments())->fetchField();
     }
     $condition->compile($this->connection, $this);
     // Don't use {} around information_schema.tables table.
-    $comment = $this->connection->query("SELECT table_comment FROM information_schema.tables WHERE " . (string) $condition, $condition->arguments())->fetchField();
+    $comment = $this->connection->query("SELECT table_comment AS table_comment FROM information_schema.tables WHERE " . (string) $condition, $condition->arguments())->fetchField();
     // Work-around for MySQL 5.0 bug http://bugs.mysql.com/bug.php?id=11379
     return preg_replace('/; InnoDB free:.*$/', '', $comment);
   }

--- a/html/includes/database/schema.inc
+++ b/html/includes/database/schema.inc
@@ -169,6 +169,11 @@ require_once dirname(__FILE__) . '/query.inc';
  */
 abstract class DatabaseSchema implements QueryPlaceholderInterface {
 
+  /**
+   * The database connection.
+   *
+   * @var DatabaseConnection
+   */
   protected $connection;
 
   /**
@@ -343,7 +348,70 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
     // couldn't use db_select() here because it would prefix
     // information_schema.tables and the query would fail.
     // Don't use {} around information_schema.tables table.
-    return $this->connection->query("SELECT table_name FROM information_schema.tables WHERE " . (string) $condition, $condition->arguments())->fetchAllKeyed(0, 0);
+    return $this->connection->query("SELECT table_name AS table_name FROM information_schema.tables WHERE " . (string) $condition, $condition->arguments())->fetchAllKeyed(0, 0);
+  }
+
+  /**
+   * Finds all tables that are like the specified base table name. This is a
+   * backport of the change made to findTables in Drupal 8 to work with virtual,
+   * un-prefixed table names. The original function is retained for Backwards
+   * Compatibility.
+   * @see https://www.drupal.org/node/2552435
+   *
+   * @param string $table_expression
+   *   An SQL expression, for example "cache_%" (without the quotes).
+   *
+   * @return array
+   *   Both the keys and the values are the matching tables.
+   */
+  public function findTablesD8($table_expression) {
+    // Load all the tables up front in order to take into account per-table
+    // prefixes. The actual matching is done at the bottom of the method.
+    $condition = $this->buildTableNameCondition('%', 'LIKE');
+    $condition->compile($this->connection, $this);
+
+    $individually_prefixed_tables = $this->connection->getUnprefixedTablesMap();
+    $default_prefix = $this->connection->tablePrefix();
+    $default_prefix_length = strlen($default_prefix);
+    $tables = array();
+    // Normally, we would heartily discourage the use of string
+    // concatenation for conditionals like this however, we
+    // couldn't use db_select() here because it would prefix
+    // information_schema.tables and the query would fail.
+    // Don't use {} around information_schema.tables table.
+    $results = $this->connection->query("SELECT table_name AS table_name FROM information_schema.tables WHERE " . (string) $condition, $condition->arguments());
+    foreach ($results as $table) {
+      // Take into account tables that have an individual prefix.
+      if (isset($individually_prefixed_tables[$table->table_name])) {
+        $prefix_length = strlen($this->connection->tablePrefix($individually_prefixed_tables[$table->table_name]));
+      }
+      elseif ($default_prefix && substr($table->table_name, 0, $default_prefix_length) !== $default_prefix) {
+        // This table name does not start the default prefix, which means that
+        // it is not managed by Drupal so it should be excluded from the result.
+        continue;
+      }
+      else {
+        $prefix_length = $default_prefix_length;
+      }
+
+      // Remove the prefix from the returned tables.
+      $unprefixed_table_name = substr($table->table_name, $prefix_length);
+
+      // The pattern can match a table which is the same as the prefix. That
+      // will become an empty string when we remove the prefix, which will
+      // probably surprise the caller, besides not being a prefixed table. So
+      // remove it.
+      if (!empty($unprefixed_table_name)) {
+        $tables[$unprefixed_table_name] = $unprefixed_table_name;
+      }
+    }
+
+    // Convert the table expression from its SQL LIKE syntax to a regular
+    // expression and escape the delimiter that will be used for matching.
+    $table_expression = str_replace(array('%', '_'), array('.*?', '.'), preg_quote($table_expression, '/'));
+    $tables = preg_grep('/^' . $table_expression . '$/i', $tables);
+
+    return $tables;
   }
 
   /**

--- a/html/includes/database/select.inc
+++ b/html/includes/database/select.inc
@@ -1520,13 +1520,16 @@ class SelectQuery extends Query implements SelectQueryInterface {
     $fields = array();
     foreach ($this->tables as $alias => $table) {
       if (!empty($table['all_fields'])) {
-        $fields[] = $this->connection->escapeTable($alias) . '.*';
+        $fields[] = $this->connection->escapeAlias($alias) . '.*';
       }
     }
     foreach ($this->fields as $alias => $field) {
+      // Note that $field['table'] holds the table alias.
+      // @see \SelectQuery::addField
+      $table = isset($field['table']) ? $this->connection->escapeAlias($field['table']) . '.' : '';
       // Always use the AS keyword for field aliases, as some
       // databases require it (e.g., PostgreSQL).
-      $fields[] = (isset($field['table']) ? $this->connection->escapeTable($field['table']) . '.' : '') . $this->connection->escapeField($field['field']) . ' AS ' . $this->connection->escapeAlias($field['alias']);
+      $fields[] = $table . $this->connection->escapeField($field['field']) . ' AS ' . $this->connection->escapeAlias($field['alias']);
     }
     foreach ($this->expressions as $alias => $expression) {
       $fields[] = $expression['expression'] . ' AS ' . $this->connection->escapeAlias($expression['alias']);
@@ -1555,7 +1558,7 @@ class SelectQuery extends Query implements SelectQueryInterface {
 
       // Don't use the AS keyword for table aliases, as some
       // databases don't support it (e.g., Oracle).
-      $query .=  $table_string . ' ' . $this->connection->escapeTable($table['alias']);
+      $query .=  $table_string . ' ' . $this->connection->escapeAlias($table['alias']);
 
       if (!empty($table['condition'])) {
         $query .= ' ON ' . $table['condition'];

--- a/html/includes/database/sqlite/database.inc
+++ b/html/includes/database/sqlite/database.inc
@@ -107,6 +107,18 @@ class DatabaseConnection_sqlite extends DatabaseConnection {
     $this->sqliteCreateFunction('substring_index', array($this, 'sqlFunctionSubstringIndex'), 3);
     $this->sqliteCreateFunction('rand', array($this, 'sqlFunctionRand'));
 
+    // Enable the Write-Ahead Logging (WAL) option for SQLite if supported.
+    // @see https://www.drupal.org/node/2348137
+    // @see https://sqlite.org/wal.html
+    if (version_compare($version, '3.7') >= 0) {
+      $connection_options += array(
+        'init_commands' => array(),
+      );
+      $connection_options['init_commands'] += array(
+        'wal' => "PRAGMA journal_mode=WAL",
+      );
+    }
+
     // Execute sqlite init_commands.
     if (isset($connection_options['init_commands'])) {
       $this->exec(implode('; ', $connection_options['init_commands']));
@@ -128,10 +140,10 @@ class DatabaseConnection_sqlite extends DatabaseConnection {
           $count = $this->query('SELECT COUNT(*) FROM ' . $prefix . '.sqlite_master WHERE type = :type AND name NOT LIKE :pattern', array(':type' => 'table', ':pattern' => 'sqlite_%'))->fetchField();
 
           // We can prune the database file if it doesn't have any tables.
-          if ($count == 0) {
-            // Detach the database.
-            $this->query('DETACH DATABASE :schema', array(':schema' => $prefix));
-            // Destroy the database file.
+          if ($count == 0 && $this->connectionOptions['database'] != ':memory:') {
+            // Detaching the database fails at this point, but no other queries
+            // are executed after the connection is destructed so we can simply
+            // remove the database file.
             unlink($this->connectionOptions['database'] . '-' . $prefix);
           }
         }
@@ -141,6 +153,18 @@ class DatabaseConnection_sqlite extends DatabaseConnection {
         }
       }
     }
+  }
+
+  /**
+   * Gets all the attached databases.
+   *
+   * @return array
+   *   An array of attached database names.
+   *
+   * @see DatabaseConnection_sqlite::__construct().
+   */
+  public function getAttachedDatabases() {
+    return $this->attachedDatabases;
   }
 
   /**

--- a/html/includes/database/sqlite/query.inc
+++ b/html/includes/database/sqlite/query.inc
@@ -23,7 +23,7 @@ class InsertQuery_sqlite extends InsertQuery {
     if (!$this->preExecute()) {
       return NULL;
     }
-    if (count($this->insertFields)) {
+    if (count($this->insertFields) || !empty($this->fromQuery)) {
       return parent::execute();
     }
     else {
@@ -36,7 +36,10 @@ class InsertQuery_sqlite extends InsertQuery {
     $comments = $this->connection->makeComment($this->comments);
 
     // Produce as many generic placeholders as necessary.
-    $placeholders = array_fill(0, count($this->insertFields), '?');
+    $placeholders = array();
+    if (!empty($this->insertFields)) {
+      $placeholders = array_fill(0, count($this->insertFields), '?');
+    }
 
     // If we're selecting from a SelectQuery, finish building the query and
     // pass it back, as any remaining options are irrelevant.

--- a/html/includes/database/sqlite/schema.inc
+++ b/html/includes/database/sqlite/schema.inc
@@ -668,6 +668,9 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
     $this->alterTable($table, $old_schema, $new_schema);
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function findTables($table_expression) {
     // Don't add the prefix, $table_expression already includes the prefix.
     $info = $this->getPrefixInfo($table_expression, FALSE);
@@ -680,4 +683,32 @@ class DatabaseSchema_sqlite extends DatabaseSchema {
     ));
     return $result->fetchAllKeyed(0, 0);
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function findTablesD8($table_expression) {
+    $tables = array();
+
+    // The SQLite implementation doesn't need to use the same filtering strategy
+    // as the parent one because individually prefixed tables live in their own
+    // schema (database), which means that neither the main database nor any
+    // attached one will contain a prefixed table name, so we just need to loop
+    // over all known schemas and filter by the user-supplied table expression.
+    $attached_dbs = $this->connection->getAttachedDatabases();
+    foreach ($attached_dbs as $schema) {
+      // Can't use query placeholders for the schema because the query would
+      // have to be :prefixsqlite_master, which does not work. We also need to
+      // ignore the internal SQLite tables.
+      $result = db_query("SELECT name FROM " . $schema . ".sqlite_master WHERE type = :type AND name LIKE :table_name AND name NOT LIKE :pattern", array(
+        ':type' => 'table',
+        ':table_name' => $table_expression,
+        ':pattern' => 'sqlite_%',
+      ));
+      $tables += $result->fetchAllKeyed(0, 0);
+    }
+
+    return $tables;
+  }
+
 }

--- a/html/includes/form.inc
+++ b/html/includes/form.inc
@@ -1361,7 +1361,10 @@ function _form_validate(&$elements, &$form_state, $form_id = NULL) {
     // The following errors are always shown.
     if (isset($elements['#needs_validation'])) {
       // Verify that the value is not longer than #maxlength.
-      if (isset($elements['#maxlength']) && drupal_strlen($elements['#value']) > $elements['#maxlength']) {
+      if (isset($elements['#maxlength']) && (isset($elements['#value']) && !is_scalar($elements['#value']))) {
+        form_error($elements, $t('An illegal value has been detected. Please contact the site administrator.'));
+      }
+      elseif (isset($elements['#maxlength']) && drupal_strlen($elements['#value']) > $elements['#maxlength']) {
         form_error($elements, $t('!name cannot be longer than %max characters but is currently %length characters long.', array('!name' => empty($elements['#title']) ? $elements['#parents'][0] : $elements['#title'], '%max' => $elements['#maxlength'], '%length' => drupal_strlen($elements['#value']))));
       }
 
@@ -2103,7 +2106,7 @@ function _form_builder_handle_input_element($form_id, &$element, &$form_state) {
       if (!$input_exists && !$form_state['rebuild'] && !$form_state['programmed']) {
         // Add the necessary parent keys to $form_state['input'] and sets the
         // element's input value to NULL.
-        drupal_array_set_nested_value($form_state['input'], $element['#parents'], NULL, TRUE);
+        drupal_array_set_nested_value($form_state['input'], $element['#parents'], NULL);
         $input_exists = TRUE;
       }
       // If we have input for the current element, assign it to the #value
@@ -4124,8 +4127,16 @@ function form_process_weight($element) {
   $max_elements = variable_get('drupal_weight_select_max', DRUPAL_WEIGHT_SELECT_MAX);
   if ($element['#delta'] <= $max_elements) {
     $element['#type'] = 'select';
+    $weights = array();
     for ($n = (-1 * $element['#delta']); $n <= $element['#delta']; $n++) {
       $weights[$n] = $n;
+    }
+    if (isset($element['#default_value'])) {
+      $default_value = (int) $element['#default_value'];
+      if (!isset($weights[$default_value])) {
+        $weights[$default_value] = $default_value;
+        ksort($weights);
+      }
     }
     $element['#options'] = $weights;
     $element += element_info('select');

--- a/html/includes/form.inc
+++ b/html/includes/form.inc
@@ -2106,7 +2106,7 @@ function _form_builder_handle_input_element($form_id, &$element, &$form_state) {
       if (!$input_exists && !$form_state['rebuild'] && !$form_state['programmed']) {
         // Add the necessary parent keys to $form_state['input'] and sets the
         // element's input value to NULL.
-        drupal_array_set_nested_value($form_state['input'], $element['#parents'], NULL);
+        drupal_array_set_nested_value($form_state['input'], $element['#parents'], NULL, TRUE);
         $input_exists = TRUE;
       }
       // If we have input for the current element, assign it to the #value

--- a/html/includes/mail.inc
+++ b/html/includes/mail.inc
@@ -12,6 +12,12 @@
  */
 define('MAIL_LINE_ENDINGS', isset($_SERVER['WINDIR']) || (isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'], 'Win32') !== FALSE) ? "\r\n" : "\n");
 
+
+/**
+ * Special characters, defined in RFC_2822.
+ */
+define('MAIL_RFC_2822_SPECIALS', '()<>[]:;@\,."');
+
 /**
  * Composes and optionally sends an e-mail message.
  *
@@ -148,8 +154,13 @@ function drupal_mail($module, $key, $to, $language, $params = array(), $from = N
     // Return-Path headers should have a domain authorized to use the originating
     // SMTP server.
     $headers['From'] = $headers['Sender'] = $headers['Return-Path'] = $default_from;
+
+    if (variable_get('mail_display_name_site_name', FALSE)) {
+      $display_name = variable_get('site_name', 'Drupal');
+      $headers['From'] = drupal_mail_format_display_name($display_name) . ' <' . $default_from . '>';
+    }
   }
-  if ($from) {
+  if ($from && $from != $default_from) {
     $headers['From'] = $from;
   }
   $message['headers'] = $headers;
@@ -558,9 +569,58 @@ function drupal_html_to_text($string, $allowed_tags = NULL) {
 }
 
 /**
+ * Return a RFC-2822 compliant "display-name" component.
+ *
+ * The "display-name" component is used in mail header "Originator" fields
+ * (From, Sender, Reply-to) to give a human-friendly description of the
+ * address, i.e. From: My Display Name <xyz@example.org>. RFC-822 and
+ * RFC-2822 define its syntax and rules. This method gets as input a string
+ * to be used as "display-name" and formats it to be RFC compliant.
+ *
+ * @param string $string
+ *   A string to be used as "display-name".
+ *
+ * @return string
+ *   A RFC compliant version of the string, ready to be used as
+ *   "display-name" in mail originator header fields.
+ */
+function drupal_mail_format_display_name($string) {
+  // Make sure we don't process html-encoded characters. They may create
+  // unneeded trouble if left encoded, besides they will be correctly
+  // processed if decoded.
+  $string = decode_entities($string);
+
+  // If string contains non-ASCII characters it must be (short) encoded
+  // according to RFC-2047. The output of a "B" (Base64) encoded-word is
+  // always safe to be used as display-name.
+  $safe_display_name = mime_header_encode($string, TRUE);
+
+  // Encoded-words are always safe to be used as display-name because don't
+  // contain any RFC 2822 "specials" characters. However
+  // mimeHeaderEncode() encodes a string only if it contains any
+  // non-ASCII characters, and leaves its value untouched (un-encoded) if
+  // ASCII only. For this reason in order to produce a valid display-name we
+  // still need to make sure there are no "specials" characters left.
+  if (preg_match('/[' . preg_quote(MAIL_RFC_2822_SPECIALS) . ']/', $safe_display_name)) {
+
+    // If string is already quoted, it may or may not be escaped properly, so
+    // don't trust it and reset.
+    if (preg_match('/^"(.+)"$/', $safe_display_name, $matches)) {
+      $safe_display_name = str_replace(array('\\\\', '\\"'), array('\\', '"'), $matches[1]);
+    }
+
+    // Transform the string in a RFC-2822 "quoted-string" by wrapping it in
+    // double-quotes. Also make sure '"' and '\' occurrences are escaped.
+    $safe_display_name = '"' . str_replace(array('\\', '"'), array('\\\\', '\\"'), $safe_display_name) . '"';
+  }
+
+  return $safe_display_name;
+}
+
+/**
  * Wraps words on a single line.
  *
- * Callback for array_walk() winthin drupal_wrap_mail().
+ * Callback for array_walk() within drupal_wrap_mail().
  */
 function _drupal_wrap_mail_line(&$line, $key, $values) {
   // Use soft-breaks only for purely quoted or unindented text.

--- a/html/includes/menu.inc
+++ b/html/includes/menu.inc
@@ -1067,7 +1067,7 @@ function menu_tree_output($tree) {
     // the active class accordingly. But local tasks do not appear in menu
     // trees, so if the current path is a local task, and this link is its
     // tab root, then we have to set the class manually.
-    if ($data['link']['href'] == $router_item['tab_root_href'] && $data['link']['href'] != $_GET['q']) {
+    if ($router_item && $data['link']['href'] == $router_item['tab_root_href'] && $data['link']['href'] != $_GET['q']) {
       $data['link']['localized_options']['attributes']['class'][] = 'active';
     }
 

--- a/html/includes/path.inc
+++ b/html/includes/path.inc
@@ -233,10 +233,6 @@ function drupal_cache_system_paths() {
  *   found.
  */
 function drupal_get_path_alias($path = NULL, $path_language = NULL) {
-  // Patch to enable path_alias_xt.module to operate.
-  if (module_exists('path_alias_xt')) {
-    return path_alias_xt_get_path_alias($path, $path_language);
-  }
   // If no path is specified, use the current page's path.
   if ($path == NULL) {
     $path = $_GET['q'];

--- a/html/includes/path.inc
+++ b/html/includes/path.inc
@@ -233,6 +233,15 @@ function drupal_cache_system_paths() {
  *   found.
  */
 function drupal_get_path_alias($path = NULL, $path_language = NULL) {
+  // Make sure nid is numeric.
+  if (isset($nid) && !is_numeric($nid)) {
+    return FALSE;
+  }
+
+  // Ignore non-numeric vid.
+  if (isset($vid) && !is_numeric($vid)) {
+    $vid = NULL;
+  }
   // If no path is specified, use the current page's path.
   if ($path == NULL) {
     $path = $_GET['q'];

--- a/html/misc/jquery.js
+++ b/html/misc/jquery.js
@@ -1,4 +1,3 @@
-
 /*!
  * jQuery JavaScript Library v1.4.4
  * http://jquery.com/

--- a/html/modules/aggregator/aggregator.info
+++ b/html/modules/aggregator/aggregator.info
@@ -7,7 +7,7 @@ files[] = aggregator.test
 configure = admin/config/services/aggregator/settings
 stylesheets[all][] = aggregator.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/aggregator/tests/aggregator_test.info
+++ b/html/modules/aggregator/tests/aggregator_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/block/block.info
+++ b/html/modules/block/block.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = block.test
 configure = admin/structure/block
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/block/tests/block_test.info
+++ b/html/modules/block/tests/block_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/block/tests/themes/block_test_theme/block_test_theme.info
+++ b/html/modules/block/tests/themes/block_test_theme/block_test_theme.info
@@ -13,7 +13,7 @@ regions[footer] = Footer
 regions[highlighted] = Highlighted
 regions[help] = Help
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/blog/blog.info
+++ b/html/modules/blog/blog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = blog.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/book/book.info
+++ b/html/modules/book/book.info
@@ -7,7 +7,7 @@ files[] = book.test
 configure = admin/content/book/settings
 stylesheets[all][] = book.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/color/color.info
+++ b/html/modules/color/color.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = color.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/comment/comment.info
+++ b/html/modules/comment/comment.info
@@ -9,7 +9,7 @@ files[] = comment.test
 configure = admin/content/comment
 stylesheets[all][] = comment.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/contact/contact.info
+++ b/html/modules/contact/contact.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = contact.test
 configure = admin/structure/contact
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/contextual/contextual.info
+++ b/html/modules/contextual/contextual.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = contextual.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/dashboard/dashboard.info
+++ b/html/modules/dashboard/dashboard.info
@@ -7,7 +7,7 @@ files[] = dashboard.test
 dependencies[] = block
 configure = admin/dashboard/customize
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/dblog/dblog.info
+++ b/html/modules/dblog/dblog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = dblog.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/field.info
+++ b/html/modules/field/field.info
@@ -11,7 +11,7 @@ dependencies[] = field_sql_storage
 required = TRUE
 stylesheets[all][] = theme/field.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/modules/field_sql_storage/field_sql_storage.info
+++ b/html/modules/field/modules/field_sql_storage/field_sql_storage.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = field_sql_storage.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/modules/field_sql_storage/field_sql_storage.test
+++ b/html/modules/field/modules/field_sql_storage/field_sql_storage.test
@@ -313,9 +313,13 @@ class FieldSqlStorageTestCase extends DrupalWebTestCase {
     $field = array('field_name' => 'test_text', 'type' => 'text', 'settings' => array('max_length' => 255));
     $field = field_create_field($field);
 
-    // Attempt to update the field in a way that would break the storage.
+    // Attempt to update the field in a way that would break the storage. The
+    // parenthesis suffix is needed because SQLite has *very* relaxed rules for
+    // data types, so we actually need to provide an invalid SQL syntax in order
+    // to break it.
+    // @see https://www.sqlite.org/datatype3.html
     $prior_field = $field;
-    $field['settings']['max_length'] = -1;
+    $field['settings']['max_length'] = '-1)';
     try {
       field_update_field($field);
       $this->fail(t('Update succeeded.'));

--- a/html/modules/field/modules/list/list.info
+++ b/html/modules/field/modules/list/list.info
@@ -7,7 +7,7 @@ dependencies[] = field
 dependencies[] = options
 files[] = tests/list.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/modules/list/tests/list_test.info
+++ b/html/modules/field/modules/list/tests/list_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/modules/number/number.info
+++ b/html/modules/field/modules/number/number.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = number.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/modules/options/options.info
+++ b/html/modules/field/modules/options/options.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = options.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/modules/text/text.info
+++ b/html/modules/field/modules/text/text.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = text.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field/tests/field_test.info
+++ b/html/modules/field/tests/field_test.info
@@ -6,7 +6,7 @@ files[] = field_test.entity.inc
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/field_ui/field_ui.info
+++ b/html/modules/field_ui/field_ui.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = field_ui.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/file/file.info
+++ b/html/modules/file/file.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = tests/file.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/file/file.module
+++ b/html/modules/file/file.module
@@ -42,6 +42,8 @@ function file_menu() {
     'access arguments' => array('access content'),
     'theme callback' => 'ajax_base_page_theme',
     'type' => MENU_CALLBACK,
+    'file' => 'node.pages.inc',
+    'file path' => drupal_get_path('module', 'node'),
   );
   $items['file/progress'] = array(
     'page callback' => 'file_ajax_progress',

--- a/html/modules/file/file.module
+++ b/html/modules/file/file.module
@@ -42,8 +42,6 @@ function file_menu() {
     'access arguments' => array('access content'),
     'theme callback' => 'ajax_base_page_theme',
     'type' => MENU_CALLBACK,
-    'file' => 'node.pages.inc',
-    'file path' => drupal_get_path('module', 'node'),
   );
   $items['file/progress'] = array(
     'page callback' => 'file_ajax_progress',
@@ -283,10 +281,11 @@ function file_ajax_upload() {
   }
   // Otherwise just add the new content class on a placeholder.
   else {
-    $form['#suffix'] .= '<span class="ajax-new-content"></span>';
+    $form['#suffix'] = (isset($form['#suffix']) ? $form['#suffix'] : '') . '<span class="ajax-new-content"></span>';
   }
 
-  $form['#prefix'] .= theme('status_messages');
+  $form['#prefix'] = (isset($form['#prefix']) ? $form['#prefix'] : '') . theme('status_messages');
+
   $output = drupal_render($form);
   $js = drupal_add_js();
   $settings = drupal_array_merge_deep_array($js['settings']['data']);

--- a/html/modules/file/tests/file_module_test.info
+++ b/html/modules/file/tests/file_module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/filter/filter.info
+++ b/html/modules/filter/filter.info
@@ -7,7 +7,7 @@ files[] = filter.test
 required = TRUE
 configure = admin/config/content/formats
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/forum/forum.info
+++ b/html/modules/forum/forum.info
@@ -9,7 +9,7 @@ files[] = forum.test
 configure = admin/structure/forum
 stylesheets[all][] = forum.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/help/help.info
+++ b/html/modules/help/help.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = help.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/image/image.info
+++ b/html/modules/image/image.info
@@ -7,7 +7,7 @@ dependencies[] = file
 files[] = image.test
 configure = admin/config/media/image-styles
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/image/tests/image_module_test.info
+++ b/html/modules/image/tests/image_module_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = image_module_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/locale/locale.info
+++ b/html/modules/locale/locale.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = locale.test
 configure = admin/config/regional/language
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/locale/locale.module
+++ b/html/modules/locale/locale.module
@@ -564,6 +564,7 @@ function locale_language_types_info() {
  * Implements hook_language_negotiation_info().
  */
 function locale_language_negotiation_info() {
+  require_once DRUPAL_ROOT . '/includes/locale.inc';
   $file = 'includes/locale.inc';
   $providers = array();
 

--- a/html/modules/locale/tests/locale_test.info
+++ b/html/modules/locale/tests/locale_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/menu/menu.info
+++ b/html/modules/menu/menu.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = menu.test
 configure = admin/structure/menu
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/node/node.info
+++ b/html/modules/node/node.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/structure/types
 stylesheets[all][] = node.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/node/node.module
+++ b/html/modules/node/node.module
@@ -961,6 +961,15 @@ function node_load_multiple($nids = array(), $conditions = array(), $reset = FAL
  *   A fully-populated node object, or FALSE if the node is not found.
  */
 function node_load($nid = NULL, $vid = NULL, $reset = FALSE) {
+  // Make sure nid is numeric.
+  if (isset($nid) && !is_numeric($nid)) {
+    return FALSE;
+  }
+
+  // Ignore non-numeric vid.
+  if (isset($vid) && !is_numeric($vid)) {
+    $vid = NULL;
+  }
   $nids = (isset($nid) ? array($nid) : array());
   $conditions = (isset($vid) ? array('vid' => $vid) : array());
   $node = node_load_multiple($nids, $conditions, $reset);

--- a/html/modules/node/node.module
+++ b/html/modules/node/node.module
@@ -961,15 +961,6 @@ function node_load_multiple($nids = array(), $conditions = array(), $reset = FAL
  *   A fully-populated node object, or FALSE if the node is not found.
  */
 function node_load($nid = NULL, $vid = NULL, $reset = FALSE) {
-  // Make sure nid is numeric.
-  if (isset($nid) && !is_numeric($nid)) {
-    return FALSE;
-  }
-
-  // Ignore non-numeric vid.
-  if (isset($vid) && !is_numeric($vid)) {
-    $vid = NULL;
-  }
   $nids = (isset($nid) ? array($nid) : array());
   $conditions = (isset($vid) ? array('vid' => $vid) : array());
   $node = node_load_multiple($nids, $conditions, $reset);

--- a/html/modules/node/tests/node_access_test.info
+++ b/html/modules/node/tests/node_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/node/tests/node_test.info
+++ b/html/modules/node/tests/node_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/node/tests/node_test_exception.info
+++ b/html/modules/node/tests/node_test_exception.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/openid/openid.info
+++ b/html/modules/openid/openid.info
@@ -5,7 +5,7 @@ package = Core
 core = 7.x
 files[] = openid.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/openid/tests/openid_test.info
+++ b/html/modules/openid/tests/openid_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = openid
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/overlay/overlay.info
+++ b/html/modules/overlay/overlay.info
@@ -4,7 +4,7 @@ package = Core
 version = VERSION
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/path/path.info
+++ b/html/modules/path/path.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = path.test
 configure = admin/config/search/path
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/php/php.info
+++ b/html/modules/php/php.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = php.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/poll/poll.info
+++ b/html/modules/poll/poll.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = poll.test
 stylesheets[all][] = poll.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/profile/profile.info
+++ b/html/modules/profile/profile.info
@@ -11,7 +11,7 @@ configure = admin/config/people/profile
 ; See user_system_info_alter().
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/rdf/rdf.info
+++ b/html/modules/rdf/rdf.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = rdf.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/rdf/tests/rdf_test.info
+++ b/html/modules/rdf/tests/rdf_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = blog
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/search/search.info
+++ b/html/modules/search/search.info
@@ -8,7 +8,7 @@ files[] = search.test
 configure = admin/config/search/settings
 stylesheets[all][] = search.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/search/tests/search_embedded_form.info
+++ b/html/modules/search/tests/search_embedded_form.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/search/tests/search_extra_type.info
+++ b/html/modules/search/tests/search_extra_type.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/search/tests/search_node_tags.info
+++ b/html/modules/search/tests/search_node_tags.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/shortcut/shortcut.info
+++ b/html/modules/shortcut/shortcut.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = shortcut.test
 configure = admin/config/user-interface/shortcut
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/drupal_web_test_case.php
+++ b/html/modules/simpletest/drupal_web_test_case.php
@@ -1677,15 +1677,12 @@ class DrupalWebTestCase extends DrupalTestCase {
     file_unmanaged_delete_recursive($this->originalFileDirectory . '/simpletest/' . substr($this->databasePrefix, 10));
 
     // Remove all prefixed tables.
-    $tables = db_find_tables($this->databasePrefix . '%');
-    $connection_info = Database::getConnectionInfo('default');
-    $tables = db_find_tables($connection_info['default']['prefix']['default'] . '%');
+    $tables = db_find_tables_d8('%');
     if (empty($tables)) {
       $this->fail('Failed to find test tables to drop.');
     }
-    $prefix_length = strlen($connection_info['default']['prefix']['default']);
     foreach ($tables as $table) {
-      if (db_drop_table(substr($table, $prefix_length))) {
+      if (db_drop_table($table)) {
         unset($tables[$table]);
       }
     }

--- a/html/modules/simpletest/simpletest.info
+++ b/html/modules/simpletest/simpletest.info
@@ -58,7 +58,7 @@ files[] = tests/upgrade/update.trigger.test
 files[] = tests/upgrade/update.field.test
 files[] = tests/upgrade/update.user.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/simpletest.module
+++ b/html/modules/simpletest/simpletest.module
@@ -563,7 +563,7 @@ function simpletest_clean_environment() {
  * Removed prefixed tables from the database that are left over from crashed tests.
  */
 function simpletest_clean_database() {
-  $tables = db_find_tables(Database::getConnection()->prefixTables('{simpletest}') . '%');
+  $tables = db_find_tables_d8(Database::getConnection()->prefixTables('{simpletest}') . '%');
   $schema = drupal_get_schema_unprocessed('simpletest');
   $count = 0;
   foreach (array_diff_key($tables, $schema) as $table) {

--- a/html/modules/simpletest/tests/actions_loop_test.info
+++ b/html/modules/simpletest/tests/actions_loop_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/ajax_forms_test.info
+++ b/html/modules/simpletest/tests/ajax_forms_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/ajax_test.info
+++ b/html/modules/simpletest/tests/ajax_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/batch_test.info
+++ b/html/modules/simpletest/tests/batch_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/boot_test_1.info
+++ b/html/modules/simpletest/tests/boot_test_1.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/boot_test_2.info
+++ b/html/modules/simpletest/tests/boot_test_2.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/common.test
+++ b/html/modules/simpletest/tests/common.test
@@ -2051,6 +2051,32 @@ class DrupalRenderTestCase extends DrupalWebTestCase {
 
     // The elements should appear in output in the same order as the array.
     $this->assertTrue(strpos($output, $second) < strpos($output, $first), 'Elements were not sorted.');
+
+    // The order of children with same weight should be preserved.
+    $element_mixed_weight = array(
+      'child5' => array('#weight' => 10),
+      'child3' => array('#weight' => -10),
+      'child1' => array(),
+      'child4' => array('#weight' => 10),
+      'child2' => array(),
+      'child6' => array('#weight' => 10),
+      'child9' => array(),
+      'child8' => array('#weight' => 10),
+      'child7' => array(),
+    );
+
+    $expected = array(
+      'child3',
+      'child1',
+      'child2',
+      'child9',
+      'child7',
+      'child5',
+      'child4',
+      'child6',
+      'child8',
+      );
+    $this->assertEqual($expected, element_children($element_mixed_weight, TRUE), 'Order of elements with the same weight is preserved.');
   }
 
   /**

--- a/html/modules/simpletest/tests/common_test.info
+++ b/html/modules/simpletest/tests/common_test.info
@@ -7,7 +7,7 @@ stylesheets[all][] = common_test.css
 stylesheets[print][] = common_test.print.css
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/common_test_cron_helper.info
+++ b/html/modules/simpletest/tests/common_test_cron_helper.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/database_test.info
+++ b/html/modules/simpletest/tests/database_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/database_test.install
+++ b/html/modules/simpletest/tests/database_test.install
@@ -217,5 +217,24 @@ function database_test_schema() {
     ),
   );
 
+  $schema['virtual'] = array(
+    'description' => 'Basic test table with a reserved name.',
+    'fields' => array(
+      'id' => array(
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'function' => array(
+        'description' => "A column with a reserved name.",
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+        'default' => '',
+      ),
+    ),
+    'primary key' => array('id'),
+  );
+
   return $schema;
 }

--- a/html/modules/simpletest/tests/database_test.test
+++ b/html/modules/simpletest/tests/database_test.test
@@ -163,6 +163,12 @@ class DatabaseTestCase extends DrupalWebTestCase {
         'priority' => 3,
       ))
       ->execute();
+
+    db_insert('virtual')
+      ->fields(array(
+        'function' => 'Function value 1',
+      ))
+      ->execute();
   }
 }
 
@@ -3457,7 +3463,6 @@ class DatabaseQueryTestCase extends DatabaseTestCase {
       ->fetchField();
     $this->assertFalse($result, 'SQL injection attempt did not result in a row being inserted in the database table.');
   }
-
 }
 
 /**
@@ -4033,6 +4038,8 @@ class ConnectionUnitTest extends DrupalUnitTestCase {
   protected $monitor;
   protected $originalCount;
 
+  protected $skipTest;
+
   public static function getInfo() {
     return array(
       'name' => 'Connection unit tests',
@@ -4053,7 +4060,7 @@ class ConnectionUnitTest extends DrupalUnitTestCase {
     // @todo Make this test driver-agnostic, or find a proper way to skip it.
     // @see http://drupal.org/node/1273478
     $connection_info = Database::getConnectionInfo('default');
-    $this->skipTest = (bool) $connection_info['default']['driver'] != 'mysql';
+    $this->skipTest = (bool) ($connection_info['default']['driver'] != 'mysql');
     if ($this->skipTest) {
       // Insert an assertion to prevent Simpletest from interpreting the test
       // as failure.
@@ -4238,5 +4245,178 @@ class ConnectionUnitTest extends DrupalUnitTestCase {
     // Verify that we are back to the original connection count.
     $this->assertNoConnection($id);
   }
+}
 
+/**
+ * Test reserved keyword handling (introduced for MySQL 8+)
+*/
+class DatabaseReservedKeywordTestCase extends DatabaseTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Reserved Keywords',
+      'description' => 'Test handling of reserved keywords.',
+      'group' => 'Database',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('database_test');
+  }
+
+  public function testTableNameQuoting() {
+    // Test db_query with {table} pattern.
+    $record = db_query('SELECT * FROM {system} LIMIT 1')->fetchObject();
+    $this->assertTrue(isset($record->filename), 'Successfully queried the {system} table.');
+
+    $connection = Database::getConnection()->getConnectionOptions();
+    if ($connection['driver'] === 'sqlite') {
+      // In SQLite simpletest's prefixed db tables exist in their own schema
+      // (e.g. simpletest124904.system), so we cannot test the schema.{table}
+      // syntax here as the table name will have the schema name prepended to it
+      // when prefixes are processed.
+      $this->assert(TRUE, 'Skipping schema.{system} test for SQLite.');
+    }
+    else {
+      $database = $connection['database'];
+      // Test db_query with schema.{table} pattern
+      db_query('SELECT * FROM ' . $database . '.{system} LIMIT 1')->fetchObject();
+      $this->assertTrue(isset($record->filename), 'Successfully queried the schema.{system} table.');
+    }
+  }
+
+  public function testSelectReservedWordTableCount() {
+    $rows = db_select('virtual')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEqual($rows, 1, 'Successful count query on a table with a reserved name.');
+  }
+
+  public function testSelectReservedWordTableSpecificField() {
+    $record = db_select('virtual')
+      ->fields('virtual', array('function'))
+      ->execute()
+      ->fetchAssoc();
+    $this->assertEqual($record['function'], 'Function value 1', 'Successfully read a field from a table with a name and column which are reserved words.');
+  }
+
+  public function testSelectReservedWordTableAllFields() {
+    $record = db_select('virtual')
+      ->fields('virtual')
+      ->execute()
+      ->fetchAssoc();
+    $this->assertEqual($record['function'], 'Function value 1', 'Successful all_fields query from a table with a name and column which are reserved words.');
+  }
+
+  public function testSelectReservedWordAliasCount() {
+    $rows = db_select('test', 'character')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEqual($rows, 4, 'Successful count query using an alias which is a reserved word.');
+  }
+
+  public function testSelectReservedWordAliasSpecificFields() {
+    $record = db_select('test', 'high_priority')
+      ->fields('high_priority', array('name'))
+      ->condition('age', 27)
+      ->execute()->fetchAssoc();
+    $this->assertEqual($record['name'], 'George', 'Successful query using an alias which is a reserved word.');
+  }
+
+  public function testSelectReservedWordAliasAllFields() {
+    $record = db_select('test', 'high_priority')
+      ->fields('high_priority')
+      ->condition('age', 27)
+      ->execute()->fetchAssoc();
+    $this->assertEqual($record['name'], 'George', 'Successful all_fields query using an alias which is a reserved word.');
+  }
+
+  public function testInsertReservedWordTable() {
+    $num_records_before = db_query('SELECT COUNT(*) FROM {virtual}')->fetchField();
+    db_insert('virtual')
+      ->fields(array(
+        'function' => 'Inserted function',
+      ))
+      ->execute();
+    $num_records_after = db_query('SELECT COUNT(*) FROM {virtual}')->fetchField();
+    $this->assertIdentical($num_records_before + 1, (int) $num_records_after, 'Successful insert into a table with a name and column which are reserved words.');
+  }
+
+  public function testDeleteReservedWordTable() {
+    $delete = db_delete('virtual')
+      ->condition('function', 'Function value 1');
+    $num_deleted = $delete->execute();
+    $this->assertEqual($num_deleted, 1, "Deleted 1 record from a table with a name and column which are reserved words..");
+  }
+
+  function testTruncateReservedWordTable() {
+    db_truncate('virtual')->execute();
+    $num_records_after = db_query("SELECT COUNT(*) FROM {virtual}")->fetchField();
+    $this->assertEqual(0, $num_records_after, 'Truncated a table with a reserved name.');
+  }
+
+  function testUpdateReservedWordTable() {
+    $num_updated = db_update('virtual')
+      ->fields(array('function' => 'Updated function'))
+      ->execute();
+    $this->assertIdentical($num_updated, 1, 'Updated 1 record in a table with a name and column which are reserved words.');
+  }
+
+  function testMergeReservedWordTable() {
+    $key = db_query('SELECT id FROM {virtual} LIMIT 1')->fetchField();
+    $num_records_before = db_query('SELECT COUNT(*) FROM {virtual}')->fetchField();
+    db_merge('virtual')
+      ->key(array('id' => $key))
+      ->fields(array('function' => 'Merged function'))
+      ->execute();
+    $num_records_after = db_query('SELECT COUNT(*) FROM {virtual}')->fetchField();
+    $this->assertIdentical($num_records_before, $num_records_after, 'Successful merge query on a table with a name and column which are reserved words.');
+  }
+}
+
+/**
+ * Test table prefix handling.
+*/
+class DatabaseTablePrefixTestCase extends DatabaseTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Table prefixes',
+      'description' => 'Test handling of table prefixes.',
+      'group' => 'Database',
+    );
+  }
+
+  public function testSchemaDotTablePrefixes() {
+    // Get a copy of the default connection options.
+    $db = Database::getConnection('default', 'default');
+    $connection_options = $db->getConnectionOptions();
+
+    if ($connection_options['driver'] === 'sqlite') {
+      // In SQLite simpletest's prefixed db tables exist in their own schema
+      // (e.g. simpletest124904.system), so we cannot test the schema.table
+      // prefix syntax here.
+      $this->assert(TRUE, 'Skipping schema.table prefixed tables test for SQLite.');
+      return;
+    }
+
+    $db_name = $connection_options['database'];
+    // This prefix is usually something like simpletest12345
+    $test_prefix = $connection_options['prefix']['default'];
+
+    // Set up a new connection with table prefixes in the form "schema.table"
+    $prefixed = $connection_options;
+    $prefixed['prefix'] = array(
+      'default' => $test_prefix,
+      'users' => $db_name . '.' . $test_prefix,
+      'role' => $db_name . '.' . $test_prefix,
+    );
+    Database::addConnectionInfo('default', 'prefixed', $prefixed);
+
+    // Test that the prefixed database connection can query the prefixed tables.
+    $num_users_prefixed = Database::getConnection('prefixed', 'default')->query('SELECT COUNT(1) FROM {users}')->fetchField();
+    $this->assertTrue((int) $num_users_prefixed > 0, 'Successfully queried the users table using a schema.table prefix');
+    $num_users_default = Database::getConnection('default', 'default')->query('SELECT COUNT(1) FROM {users}')->fetchField();
+    $this->assertEqual($num_users_default, $num_users_prefixed, 'Verified results of query using a connection with schema.table prefixed tables');
+  }
 }

--- a/html/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
+++ b/html/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/html/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/html/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/entity_cache_test.info
+++ b/html/modules/simpletest/tests/entity_cache_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = entity_cache_test_dependency
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/entity_cache_test_dependency.info
+++ b/html/modules/simpletest/tests/entity_cache_test_dependency.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/entity_crud_hook_test.info
+++ b/html/modules/simpletest/tests/entity_crud_hook_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/entity_query_access_test.info
+++ b/html/modules/simpletest/tests/entity_query_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/error_test.info
+++ b/html/modules/simpletest/tests/error_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/file_test.info
+++ b/html/modules/simpletest/tests/file_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = file_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/filter_test.info
+++ b/html/modules/simpletest/tests/filter_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/form.test
+++ b/html/modules/simpletest/tests/form.test
@@ -591,6 +591,19 @@ class FormElementTestCase extends DrupalWebTestCase {
       )));
     }
   }
+
+  /**
+   * Tests Weight form element #default_value behavior.
+   */
+  public function testWeightDefaultValue() {
+    $element = array(
+      '#type' => 'weight',
+      '#delta' => 10,
+      '#default_value' => 15,
+    );
+    $element = form_process_weight($element);
+    $this->assertTrue(isset($element['#options'][$element['#default_value']]), 'Default value exists in #options list');
+  }
 }
 
 /**

--- a/html/modules/simpletest/tests/form_test.info
+++ b/html/modules/simpletest/tests/form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/image_test.info
+++ b/html/modules/simpletest/tests/image_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/mail.test
+++ b/html/modules/simpletest/tests/mail.test
@@ -60,6 +60,81 @@ class MailTestCase extends DrupalWebTestCase implements MailSystemInterface {
   }
 
   /**
+   * Checks for the site name in an auto-generated From: header.
+   */
+  function testFromHeader() {
+    global $language;
+    $default_from = variable_get('site_mail', ini_get('sendmail_from'));
+    $site_name = variable_get('site_name', 'Drupal');
+
+    // Reset the class variable holding a copy of the last sent message.
+    self::$sent_message = NULL;
+    // Send an e-mail with a sender address specified.
+    $from_email = 'someone_else@example.com';
+    $message = drupal_mail('simpletest', 'from_test', 'from_test@example.com', $language, array(), $from_email);
+    // Test that the from e-mail is just the e-mail and not the site name and
+    // default sender e-mail.
+    $this->assertEqual($from_email, self::$sent_message['headers']['From']);
+
+    // Check default behavior is only email in FROM header.
+    self::$sent_message = NULL;
+    // Send an e-mail and check that the From-header contains only default mail address.
+    variable_del('mail_display_name_site_name');
+    $message = drupal_mail('simpletest', 'from_test', 'from_test@example.com', $language);
+    $this->assertEqual($default_from, self::$sent_message['headers']['From']);
+
+    self::$sent_message = NULL;
+    // Send an e-mail and check that the From-header contains the site name.
+    variable_set('mail_display_name_site_name', TRUE);
+    $message = drupal_mail('simpletest', 'from_test', 'from_test@example.com', $language);
+    $this->assertEqual($site_name . ' <' . $default_from . '>', self::$sent_message['headers']['From']);
+  }
+
+  /**
+   * Checks for the site name in an auto-generated From: header.
+   */
+  function testFromHeaderRfc2822Compliant() {
+    global $language;
+    $default_from = variable_get('site_mail', ini_get('sendmail_from'));
+
+    // Enable adding a site name to From.
+    variable_set('mail_display_name_site_name', TRUE);
+
+    $site_names = array(
+      // Simple ASCII characters.
+      'Test site' => 'Test site',
+      // ASCII with html entity.
+      'Test &amp; site' => 'Test & site',
+      // Non-ASCII characters.
+      'Tést site' => '=?UTF-8?B?VMOpc3Qgc2l0ZQ==?=',
+      // Non-ASCII with special characters.
+      'Tést; site' => '=?UTF-8?B?VMOpc3Q7IHNpdGU=?=',
+      // Non-ASCII with html entity.
+      'T&eacute;st; site' => '=?UTF-8?B?VMOpc3Q7IHNpdGU=?=',
+      // ASCII with special characters.
+      'Test; site' => '"Test; site"',
+      // ASCII with special characters as html entity.
+      'Test &lt; site' => '"Test < site"',
+      // ASCII with special characters and '\'.
+      'Test; \ "site"' => '"Test; \\\\ \"site\""',
+      // String already RFC-2822 compliant.
+      '"Test; site"' => '"Test; site"',
+      // String already RFC-2822 compliant.
+      '"Test; \\\\ \"site\""' => '"Test; \\\\ \"site\""',
+    );
+
+    foreach ($site_names as $original_name => $safe_string) {
+      variable_set('site_name', $original_name);
+
+      // Reset the class variable holding a copy of the last sent message.
+      self::$sent_message = NULL;
+      // Send an e-mail and check that the From-header contains is RFC-2822 compliant.
+      drupal_mail('simpletest', 'from_test', 'from_test@example.com', $language);
+      $this->assertEqual($safe_string . ' <' . $default_from . '>', self::$sent_message['headers']['From']);
+    }
+  }
+
+  /**
    * Concatenate and wrap the e-mail body for plain-text mails.
    *
    * @see DefaultMailSystem

--- a/html/modules/simpletest/tests/menu_test.info
+++ b/html/modules/simpletest/tests/menu_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/module_test.info
+++ b/html/modules/simpletest/tests/module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/path_test.info
+++ b/html/modules/simpletest/tests/path_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/psr_0_test/psr_0_test.info
+++ b/html/modules/simpletest/tests/psr_0_test/psr_0_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/psr_4_test/psr_4_test.info
+++ b/html/modules/simpletest/tests/psr_4_test/psr_4_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/requirements1_test.info
+++ b/html/modules/simpletest/tests/requirements1_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/requirements2_test.info
+++ b/html/modules/simpletest/tests/requirements2_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/schema.test
+++ b/html/modules/simpletest/tests/schema.test
@@ -381,4 +381,60 @@ class SchemaTestCase extends DrupalWebTestCase {
 
     db_drop_field($table_name, $field_name);
   }
+
+  /**
+   * Tests the findTables() method.
+   */
+  public function testFindTables() {
+    // We will be testing with three tables, two of them using the default
+    // prefix and the third one with an individually specified prefix.
+
+    // Set up a new connection with different connection info.
+    $connection_info = Database::getConnectionInfo();
+
+    // Add per-table prefix to the second table.
+    $new_connection_info = $connection_info['default'];
+    $new_connection_info['prefix']['test_2_table'] = $new_connection_info['prefix']['default'] . '_shared_';
+    Database::addConnectionInfo('test', 'default', $new_connection_info);
+
+    Database::setActiveConnection('test');
+
+    // Create the tables.
+    $table_specification = array(
+      'description' => 'Test table.',
+      'fields' => array(
+        'id'  => array(
+          'type' => 'int',
+          'default' => NULL,
+        ),
+      ),
+    );
+    Database::getConnection()->schema()->createTable('test_1_table', $table_specification);
+    Database::getConnection()->schema()->createTable('test_2_table', $table_specification);
+    Database::getConnection()->schema()->createTable('the_third_table', $table_specification);
+
+    // Check the "all tables" syntax.
+    $tables = Database::getConnection()->schema()->findTablesD8('%');
+    sort($tables);
+    $expected = array(
+      'test_1_table',
+      // This table uses a per-table prefix, yet it is returned as un-prefixed.
+      'test_2_table',
+      'the_third_table',
+    );
+
+    $this->assertTrue(!array_diff($expected, $tables), 'All tables were found.');
+
+    // Check the restrictive syntax.
+    $tables = Database::getConnection()->schema()->findTablesD8('test_%');
+    sort($tables);
+    $expected = array(
+      'test_1_table',
+      'test_2_table',
+    );
+    $this->assertEqual($tables, $expected, 'Two tables were found.');
+
+    // Go back to the initial connection.
+    Database::setActiveConnection('default');
+  }
 }

--- a/html/modules/simpletest/tests/session_test.info
+++ b/html/modules/simpletest/tests/session_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/system_dependencies_test.info
+++ b/html/modules/simpletest/tests/system_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = _missing_dependency
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = system_incompatible_core_version_test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/system_incompatible_core_version_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_core_version_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 5.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
@@ -7,7 +7,7 @@ hidden = TRUE
 ; system_incompatible_module_version_test declares version 1.0
 dependencies[] = system_incompatible_module_version_test (>2.0)
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/system_incompatible_module_version_test.info
+++ b/html/modules/simpletest/tests/system_incompatible_module_version_test.info
@@ -5,7 +5,7 @@ version = 1.0
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/system_project_namespace_test.info
+++ b/html/modules/simpletest/tests/system_project_namespace_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = drupal:filter
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/system_test.info
+++ b/html/modules/simpletest/tests/system_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = system_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/taxonomy_test.info
+++ b/html/modules/simpletest/tests/taxonomy_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = taxonomy
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/theme_test.info
+++ b/html/modules/simpletest/tests/theme_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
+++ b/html/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 settings[basetheme_only] = base theme value
 settings[subtheme_override] = base theme value
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
+++ b/html/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 
 settings[subtheme_override] = subtheme value
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/themes/test_theme/test_theme.info
+++ b/html/modules/simpletest/tests/themes/test_theme/test_theme.info
@@ -17,7 +17,7 @@ stylesheets[all][] = system.base.css
 
 settings[theme_test_setting] = default value
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
+++ b/html/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
@@ -4,7 +4,7 @@ core = 7.x
 hidden = TRUE
 engine = nyan_cat
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/update_script_test.info
+++ b/html/modules/simpletest/tests/update_script_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/update_test_1.info
+++ b/html/modules/simpletest/tests/update_test_1.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/update_test_2.info
+++ b/html/modules/simpletest/tests/update_test_2.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/update_test_3.info
+++ b/html/modules/simpletest/tests/update_test_3.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/url_alter_test.info
+++ b/html/modules/simpletest/tests/url_alter_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/simpletest/tests/xmlrpc_test.info
+++ b/html/modules/simpletest/tests/xmlrpc_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/statistics/statistics.info
+++ b/html/modules/statistics/statistics.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = statistics.test
 configure = admin/config/system/statistics
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/syslog/syslog.info
+++ b/html/modules/syslog/syslog.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = syslog.test
 configure = admin/config/development/logging
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/system/system.info
+++ b/html/modules/system/system.info
@@ -12,7 +12,7 @@ files[] = system.test
 required = TRUE
 configure = admin/config/system
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/system/system.tar.inc
+++ b/html/modules/system/system.tar.inc
@@ -2178,6 +2178,14 @@ class Archive_Tar
                             }
                         }
                     } elseif ($v_header['typeflag'] == "2") {
+                        if (strpos(realpath(dirname($v_header['link'])), realpath($p_path)) !== 0) {
+                            $this->_error(
+                                'Out-of-path file extraction {'
+                                . $v_header['filename'] . ' --> ' .
+                                $v_header['link'] . '}'
+                            );
+                            return false;
+                        }
                         if (!$p_symlinks) {
                             $this->_warning('Symbolic links are not allowed. '
                                 . 'Unable to extract {'

--- a/html/modules/system/system.test
+++ b/html/modules/system/system.test
@@ -28,7 +28,7 @@ class ModuleTestCase extends DrupalWebTestCase {
    *   specified base table. Defaults to TRUE.
    */
   function assertTableCount($base_table, $count = TRUE) {
-    $tables = db_find_tables(Database::getConnection()->prefixTables('{' . $base_table . '}') . '%');
+    $tables = db_find_tables_d8($base_table . '%');
 
     if ($count) {
       return $this->assertTrue($tables, format_string('Tables matching "@base_table" found.', array('@base_table' => $base_table)));
@@ -779,14 +779,14 @@ class IPAddressBlockingTestCase extends DrupalWebTestCase {
     $submit_ip = $_SERVER['REMOTE_ADDR'] = '192.168.1.1';
     system_block_ip_action();
     system_block_ip_action();
-    $ip_count = db_query("SELECT iid from {blocked_ips} WHERE ip = :ip", array(':ip' => $submit_ip))->rowCount();
+    $ip_count = db_query("SELECT COUNT(*) from {blocked_ips} WHERE ip = :ip", array(':ip' => $submit_ip))->fetchColumn();
     $this->assertEqual('1', $ip_count);
     drupal_static_reset('ip_address');
     $submit_ip = $_SERVER['REMOTE_ADDR'] = ' ';
     system_block_ip_action();
     system_block_ip_action();
     system_block_ip_action();
-    $ip_count = db_query("SELECT iid from {blocked_ips} WHERE ip = :ip", array(':ip' => $submit_ip))->rowCount();
+    $ip_count = db_query("SELECT COUNT(*) from {blocked_ips} WHERE ip = :ip", array(':ip' => $submit_ip))->fetchColumn();
     $this->assertEqual('1', $ip_count);
   }
 }

--- a/html/modules/system/tests/cron_queue_test.info
+++ b/html/modules/system/tests/cron_queue_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/system/tests/system_cron_test.info
+++ b/html/modules/system/tests/system_cron_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/taxonomy/taxonomy.info
+++ b/html/modules/taxonomy/taxonomy.info
@@ -8,7 +8,7 @@ files[] = taxonomy.module
 files[] = taxonomy.test
 configure = admin/structure/taxonomy
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/toolbar/toolbar.info
+++ b/html/modules/toolbar/toolbar.info
@@ -4,7 +4,7 @@ core = 7.x
 package = Core
 version = VERSION
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/translation/tests/translation_test.info
+++ b/html/modules/translation/tests/translation_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/translation/translation.info
+++ b/html/modules/translation/translation.info
@@ -6,7 +6,7 @@ version = VERSION
 core = 7.x
 files[] = translation.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/trigger/tests/trigger_test.info
+++ b/html/modules/trigger/tests/trigger_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/trigger/trigger.info
+++ b/html/modules/trigger/trigger.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = trigger.test
 configure = admin/structure/trigger
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/tests/aaa_update_test.info
+++ b/html/modules/update/tests/aaa_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/tests/bbb_update_test.info
+++ b/html/modules/update/tests/bbb_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/tests/ccc_update_test.info
+++ b/html/modules/update/tests/ccc_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
+++ b/html/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
@@ -3,7 +3,7 @@ description = Test theme which is used as admin theme.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
+++ b/html/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
@@ -3,7 +3,7 @@ description = Test theme which acts as a base theme for other test subthemes.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
+++ b/html/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
@@ -4,7 +4,7 @@ core = 7.x
 base theme = update_test_basetheme
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/tests/update_test.info
+++ b/html/modules/update/tests/update_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/update/update.info
+++ b/html/modules/update/update.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = update.test
 configure = admin/reports/updates/settings
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/user/tests/user_flood_test.info
+++ b/html/modules/user/tests/user_flood_test.info
@@ -1,10 +1,9 @@
-name = Tracker
-description = Enables tracking of recent content for users.
-dependencies[] = comment
-package = Core
+name = "User module flood control tests"
+description = "Support module for user flood control testing."
+package = Testing
 version = VERSION
 core = 7.x
-files[] = tracker.test
+hidden = TRUE
 
 ; Information added by Drupal.org packaging script on 2021-01-20
 version = "7.78"

--- a/html/modules/user/tests/user_flood_test.module
+++ b/html/modules/user/tests/user_flood_test.module
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Dummy module implementing hook_user_flood_control.
+ */
+
+/**
+ * Implements hook_user_flood_control().
+ */
+function user_flood_test_user_flood_control($ip, $username = FALSE) {
+  if (!empty($username)) {
+    watchdog('user_flood_test', 'hook_user_flood_control was passed username %username and IP %ip.', array('%username' => $username, '%ip' => $ip));
+  }
+  else {
+    watchdog('user_flood_test', 'hook_user_flood_control was passed IP %ip.', array('%ip' => $ip));
+  }
+}

--- a/html/modules/user/tests/user_form_test.info
+++ b/html/modules/user/tests/user_form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/user/tests/user_form_test.module
+++ b/html/modules/user/tests/user_form_test.module
@@ -35,7 +35,7 @@ function user_form_test_current_password($form, &$form_state, $account) {
     '#description' => t('A field that would require a correct password to change.'),
     '#required' => TRUE,
   );
-  
+
   $form['current_pass'] = array(
     '#type' => 'password',
     '#title' => t('Current password'),

--- a/html/modules/user/tests/user_session_test.info
+++ b/html/modules/user/tests/user_session_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/user/user.api.php
+++ b/html/modules/user/user.api.php
@@ -473,5 +473,35 @@ function hook_user_role_delete($role) {
 }
 
 /**
+ * Respond to user flood control events.
+ *
+ * This hook allows you act when an unsuccessful user login has triggered
+ * flood control. This means that either an IP address or a specific user
+ * account has been temporarily blocked from logging in.
+ *
+ * @param $ip
+ *   The IP address that triggered flood control.
+ * @param $username
+ *   The username that has been temporarily blocked.
+ *
+ * @see user_login_final_validate()
+ */
+function hook_user_flood_control($ip, $username = FALSE) {
+  if (!empty($username)) {
+    // Do something with the blocked $username and $ip. For example, send an
+    // e-mail to the user and/or site administrator.
+
+    // Drupal core uses this hook to log the event:
+    watchdog('user', 'Flood control blocked login attempt for %user from %ip.', array('%user' => $username, '%ip' => $ip));
+  }
+  else {
+    // Do something with the blocked $ip. For example, add it to a block-list.
+
+    // Drupal core uses this hook to log the event:
+    watchdog('user', 'Flood control blocked login attempt from %ip.', array('%ip' => $ip));
+  }
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/html/modules/user/user.info
+++ b/html/modules/user/user.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/config/people
 stylesheets[all][] = user.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/modules/user/user.module
+++ b/html/modules/user/user.module
@@ -2225,11 +2225,17 @@ function user_login_final_validate($form, &$form_state) {
     if (isset($form_state['flood_control_triggered'])) {
       if ($form_state['flood_control_triggered'] == 'user') {
         form_set_error('name', format_plural(variable_get('user_failed_login_user_limit', 5), 'Sorry, there has been more than one failed login attempt for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', 'Sorry, there have been more than @count failed login attempts for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
+        module_invoke_all('user_flood_control', ip_address(), $form_state['values']['name']);
       }
       else {
         // We did not find a uid, so the limit is IP-based.
         form_set_error('name', t('Sorry, too many failed login attempts from your IP address. This IP address is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
+        module_invoke_all('user_flood_control', ip_address());
       }
+      // We cannot call drupal_access_denied() here as that can result in an
+      // infinite loop if the login form is rendered on the 403 page (e.g. in a
+      // block). So add the 403 header and allow form processing to finish.
+      drupal_add_http_header('Status', '403 Forbidden');
     }
     else {
       // Use $form_state['input']['name'] here to guarantee that we send
@@ -2244,6 +2250,23 @@ function user_login_final_validate($form, &$form_state) {
     // Clear past failures for this user so as not to block a user who might
     // log in and out more than once in an hour.
     flood_clear_event('failed_login_attempt_user', $form_state['flood_control_user_identifier']);
+  }
+}
+
+/**
+ * Implements hook_user_flood_control().
+ */
+function user_user_flood_control($ip, $username = FALSE) {
+  if (variable_get('log_user_flood_control', TRUE)) {
+    if (!empty($username)) {
+      watchdog('user', 'Flood control blocked login attempt for %user from %ip.', array(
+        '%user' => $username,
+        '%ip' => $ip
+      ));
+    }
+    else {
+      watchdog('user', 'Flood control blocked login attempt from %ip.', array('%ip' => $ip));
+    }
   }
 }
 

--- a/html/modules/user/user.pages.inc
+++ b/html/modules/user/user.pages.inc
@@ -66,6 +66,22 @@ function user_pass() {
  * @see user_pass_submit()
  */
 function user_pass_validate($form, &$form_state) {
+  if (isset($form_state['values']['name']) && !is_scalar($form_state['values']['name'])) {
+    form_set_error('name', t('An illegal value has been detected. Please contact the site administrator.'));
+    return;
+  }
+  $user_pass_reset_ip_window = variable_get('user_pass_reset_ip_window', 3600);
+  // Do not allow any password reset from the current user's IP if the limit
+  // has been reached. Default is 50 attempts allowed in one hour. This is
+  // independent of the per-user limit to catch attempts from one IP to request
+  // resets for many different user accounts. We have a reasonably high limit
+  // since there may be only one apparent IP for all users at an institution.
+  if (!flood_is_allowed('pass_reset_ip', variable_get('user_pass_reset_ip_limit', 50), $user_pass_reset_ip_window)) {
+    form_set_error('name', t('Sorry, too many password reset attempts from your IP address. This IP address is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
+    return;
+  }
+  // Always register an per-IP event.
+  flood_register_event('pass_reset_ip', $user_pass_reset_ip_window);
   $name = trim($form_state['values']['name']);
   // Try to load by email.
   $users = user_load_multiple(array(), array('mail' => $name, 'status' => '1'));
@@ -76,6 +92,19 @@ function user_pass_validate($form, &$form_state) {
     $account = reset($users);
   }
   if (isset($account->uid)) {
+    // Register user flood events based on the uid only, so they can be cleared
+    // when a password is reset successfully.
+    $identifier = $account->uid;
+    $user_pass_reset_user_window = variable_get('user_pass_reset_user_window', 21600);
+    $user_pass_reset_user_limit = variable_get('user_pass_reset_user_limit', 5);
+    // Don't allow password reset if the limit for this user has been reached.
+    // Default is to allow 5 passwords resets every 6 hours.
+    if (!flood_is_allowed('pass_reset_user', $user_pass_reset_user_limit, $user_pass_reset_user_window, $identifier)) {
+      form_set_error('name', format_plural($user_pass_reset_user_limit, 'Sorry, there has been more than one password reset attempt for this account. It is temporarily blocked. Try again later or <a href="@url">login with your password</a>.', 'Sorry, there have been more than @count password reset attempts for this account. It is temporarily blocked. Try again later or <a href="@url">login with your password</a>.', array('@url' => url('user/login'))));
+      return;
+    }
+    // Register a per-user event.
+    flood_register_event('pass_reset_user', $user_pass_reset_user_window, $identifier);
     form_set_value(array('#parents' => array('account')), $account, $form_state);
   }
   else {
@@ -161,6 +190,8 @@ function user_pass_reset($form, &$form_state, $uid, $timestamp, $hashed_pass, $a
           // user_login_finalize() also updates the login timestamp of the
           // user, which invalidates further use of the one-time login link.
           user_login_finalize();
+          // Clear any password reset flood events for this user.
+          flood_clear_event('pass_reset_user', $account->uid);
           watchdog('user', 'User %name used one-time login link at time %timestamp.', array('%name' => $account->name, '%timestamp' => $timestamp));
           drupal_set_message(t('You have just used your one-time login link. It is no longer necessary to use this link to log in. Please change your password.'));
           // Let the user's password be changed without the current password check.

--- a/html/modules/user/user.test
+++ b/html/modules/user/user.test
@@ -322,7 +322,7 @@ class UserLoginTestCase extends DrupalWebTestCase {
   }
 
   function setUp() {
-    parent::setUp('user_session_test');
+    parent::setUp('user_session_test', 'user_flood_test');
   }
 
   /**
@@ -453,12 +453,19 @@ class UserLoginTestCase extends DrupalWebTestCase {
     $this->drupalPost('user', $edit, t('Log in'));
     $this->assertNoFieldByXPath("//input[@name='pass' and @value!='']", NULL, 'Password value attribute is blank.');
     if (isset($flood_trigger)) {
+      $this->assertResponse(403);
+      $user_log = db_query_range('SELECT message FROM {watchdog} WHERE type = :type ORDER BY wid DESC', 0, 1, array(':type' => 'user'))->fetchField();
+      $user_flood_test_log = db_query_range('SELECT message FROM {watchdog} WHERE type = :type ORDER BY wid DESC', 0, 1, array(':type' => 'user_flood_test'))->fetchField();
       if ($flood_trigger == 'user') {
-        $this->assertRaw(format_plural(variable_get('user_failed_login_user_limit', 5), 'Sorry, there has been more than one failed login attempt for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', 'Sorry, there have been more than @count failed login attempts for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
+        $this->assertRaw(t('Sorry, there have been more than @count failed login attempts for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'), '@count' => variable_get('user_failed_login_user_limit', 5))));
+        $this->assertEqual('Flood control blocked login attempt for %user from %ip.', $user_log, 'A watchdog message was logged for the login attempt blocked by flood control per user');
+        $this->assertEqual('hook_user_flood_control was passed username %username and IP %ip.', $user_flood_test_log, 'hook_user_flood_control was invoked by flood control per user');
       }
       else {
         // No uid, so the limit is IP-based.
         $this->assertRaw(t('Sorry, too many failed login attempts from your IP address. This IP address is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
+        $this->assertEqual('Flood control blocked login attempt from %ip.', $user_log, 'A watchdog message was logged for the login attempt blocked by flood control per IP');
+        $this->assertEqual('hook_user_flood_control was passed IP %ip.', $user_flood_test_log, 'hook_user_flood_control was invoked by flood control per IP');
       }
     }
     else {
@@ -507,6 +514,8 @@ class UserPasswordResetTestCase extends DrupalWebTestCase {
     $this->drupalPost('user/password', $edit, t('E-mail new password'));
     // Confirm the password reset.
     $this->assertText(t('Further instructions have been sent to your e-mail address.'), 'Password reset instructions mailed message displayed.');
+    // Ensure that flood control was not triggered.
+    $this->assertNoText(t('is temporarily blocked. Try again later'), 'Flood control was not triggered by single password reset.');
 
     // Create an image field to enable an Ajax request on the user profile page.
     $field = array(
@@ -550,6 +559,84 @@ class UserPasswordResetTestCase extends DrupalWebTestCase {
     $edit = array('pass[pass1]' => $password, 'pass[pass2]' => $password);
     $this->drupalPost(NULL, $edit, t('Save'));
     $this->assertText(t('The changes have been saved.'), 'Forgotten password changed.');
+  }
+
+  /**
+   * Test user-based flood control on password reset.
+   */
+  function testPasswordResetFloodControlPerUser() {
+    // Set a very low limit for testing.
+    variable_set('user_pass_reset_user_limit', 2);
+
+    // Create a user.
+    $account = $this->drupalCreateUser();
+    $this->drupalLogin($account);
+    $this->drupalLogout();
+
+    $edit = array('name' => $account->name);
+
+    // Try 2 requests that should not trigger flood control.
+    for ($i = 0; $i < 2; $i++) {
+      $this->drupalPost('user/password', $edit, t('E-mail new password'));
+      // Confirm the password reset.
+      $this->assertText(t('Further instructions have been sent to your e-mail address.'), 'Password reset instructions mailed message displayed.');
+      // Ensure that flood control was not triggered.
+      $this->assertNoText(t('is temporarily blocked. Try again later'), 'Flood control was not triggered by password reset.');
+    }
+
+    // A successful password reset should clear flood events.
+    $resetURL = $this->getResetURL();
+    $this->drupalGet($resetURL);
+
+    // Check successful login.
+    $this->drupalPost(NULL, NULL, t('Log in'));
+    $this->drupalLogout();
+
+    // Try 2 requests that should not trigger flood control.
+    for ($i = 0; $i < 2; $i++) {
+      $this->drupalPost('user/password', $edit, t('E-mail new password'));
+      // Confirm the password reset.
+      $this->assertText(t('Further instructions have been sent to your e-mail address.'), 'Password reset instructions mailed message displayed.');
+      // Ensure that flood control was not triggered.
+      $this->assertNoText(t('is temporarily blocked. Try again later'), 'Flood control was not triggered by password reset.');
+    }
+
+    // The next request should trigger flood control
+    $this->drupalPost('user/password', $edit, t('E-mail new password'));
+    // Confirm the password reset was blocked.
+    $this->assertNoText(t('Further instructions have been sent to your e-mail address.'), 'Password reset instructions mailed message not displayed for excessive password resets.');
+    // Ensure that flood control was triggered.
+    $this->assertText(t('Sorry, there have been more than 2 password reset attempts for this account. It is temporarily blocked.'), 'Flood control was triggered by excessive password resets for one user.');
+  }
+
+  /**
+   * Test IP-based flood control on password reset.
+   */
+  function testPasswordResetFloodControlPerIp() {
+    // Set a very low limit for testing.
+    variable_set('user_pass_reset_ip_limit', 2);
+
+    // Try 2 requests that should not trigger flood control.
+    for ($i = 0; $i < 2; $i++) {
+      $name = $this->randomName();
+      $edit = array('name' => $name);
+      $this->drupalPost('user/password', $edit, t('E-mail new password'));
+      // Confirm the password reset was not blocked. Note that @name is used
+      // instead of %name as assertText() works with plain text not HTML.
+      $this->assertText(t('Sorry, @name is not recognized as a user name or an e-mail address.', array('@name' => $name)), 'User name not recognized message displayed.');
+      // Ensure that flood control was not triggered.
+      $this->assertNoText(t('is temporarily blocked. Try again later'), 'Flood control was not triggered by password reset.');
+    }
+
+    // The next request should trigger flood control
+    $name = $this->randomName();
+    $edit = array('name' => $name);
+    $this->drupalPost('user/password', $edit, t('E-mail new password'));
+    // Confirm the password reset was blocked early. Note that @name is used
+    // instead of %name as assertText() works with plain text not HTML.
+    $this->assertNoText(t('Sorry, @name is not recognized as a user name or an e-mail address.', array('@name' => $name)), 'User name not recognized message not displayed.');
+    // Ensure that flood control was triggered.
+    $this->assertText(t('Sorry, too many password reset attempts from your IP address. This IP address is temporarily blocked.'), 'Flood control was triggered by excessive password resets from one IP.');
   }
 
   /**

--- a/html/profiles/minimal/minimal.info
+++ b/html/profiles/minimal/minimal.info
@@ -5,7 +5,7 @@ core = 7.x
 dependencies[] = block
 dependencies[] = dblog
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/profiles/standard/standard.info
+++ b/html/profiles/standard/standard.info
@@ -24,7 +24,7 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = rdf
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/html/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 files[] = drupal_system_listing_compatible_test.test
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/html/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -8,7 +8,7 @@ version = VERSION
 core = 6.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/profiles/testing/testing.info
+++ b/html/profiles/testing/testing.info
@@ -4,7 +4,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/robots.txt
+++ b/html/robots.txt
@@ -91,3 +91,10 @@ Disallow: /?q=user/login/
 Disallow: /?q=user/logout/
 Disallow: */calendar.ics/*
 Disallow: */events/pdf$
+# Searches (everywhere)
+Disallow: /en/search
+Disallow: /es/search
+Disallow: /fr/search
+Disallow: /ru/search
+Disallow: */search
+Disallow: *?search

--- a/html/scripts/run-tests.sh
+++ b/html/scripts/run-tests.sh
@@ -264,6 +264,10 @@ function simpletest_script_init($server_software) {
     // '_' is an environment variable set by the shell. It contains the command that was executed.
     $php = $php_env;
   }
+  elseif (defined('PHP_BINARY') && $php_env = PHP_BINARY) {
+    // 'PHP_BINARY' specifies the PHP binary path during script execution. Available since PHP 5.4.
+    $php = $php_env;
+  }
   elseif ($sudo = getenv('SUDO_COMMAND')) {
     // 'SUDO_COMMAND' is an environment variable set by the sudo program.
     // Extract only the PHP interpreter, not the rest of the command.

--- a/html/themes/bartik/bartik.info
+++ b/html/themes/bartik/bartik.info
@@ -34,7 +34,7 @@ regions[footer] = Footer
 settings[shortcut_module_link] = 0
 
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/themes/garland/garland.info
+++ b/html/themes/garland/garland.info
@@ -7,7 +7,7 @@ stylesheets[all][] = style.css
 stylesheets[print][] = print.css
 settings[garland_width] = fluid
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/themes/seven/seven.info
+++ b/html/themes/seven/seven.info
@@ -13,7 +13,7 @@ regions[page_bottom] = Page bottom
 regions[sidebar_first] = First sidebar
 regions_hidden[] = sidebar_first
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/html/themes/stark/stark.info
+++ b/html/themes/stark/stark.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 stylesheets[all][] = layout.css
 
-; Information added by Drupal.org packaging script on 2020-11-26
-version = "7.75"
+; Information added by Drupal.org packaging script on 2021-01-20
+version = "7.78"
 project = "drupal"
-datestamp = "1606357834"
+datestamp = "1611162699"

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,6 +1,6 @@
 {
     "php": {
-        "version": "7.3"
+        "version": "7.4"
     },
     "symfony/flex": {
         "version": "1.0",

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,6 +1,6 @@
 {
     "php": {
-        "version": "7.4"
+        "version": "7.3.26"
     },
     "symfony/flex": {
         "version": "1.0",


### PR DESCRIPTION
Something very strange with composer (or my understanding of it). 

As mentioned https://humanitarian.atlassian.net/browse/OPS-7230?focusedCommentId=121271, it deletes a lot of custom code, which I'd seen before. Others have found similar things happening - https://github.com/drupal-composer/preserve-paths/issues/10 - but the fix in that issue no longer works.

Worse, I found that `composer require drupal/drupal:7.78` updates composer.json and composer.lock, but not the core drupal files. In the end I resorted to `drush up drupal`, and manually applying all the patches.

I have another branch with `composer update`, which did update the core, but everything else with it and I found many extra errors in the logs - mainly panels and og related. I made a ticket to come back for a closer look: https://humanitarian.atlassian.net/browse/HRINFO-1027

