### PR TITLE
[HRINFO-1029] patch i18n cache issue

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -19,6 +19,9 @@
       "drupal/hybridauth": {
         "https://www.drupal.org/project/hybridauth/issues/3154070": "https://www.drupal.org/files/issues/2020-06-23/session_already_exist_exception-3154070-7.patch"
       },
+      "drupal/i18n": {
+        "HRINFO-1029 https://www.drupal.org/project/i18n/issues/2082573": "https://www.drupal.org/files/issues/2018-06-24/i18n-fatal-error-undefined-strings_update-2082573-54.patch"
+      },
       "drupal/og": {
         "User can create node without permission": "https://patch-diff.githubusercontent.com/raw/Gizra/og/pull/442.patch",
         "HR.info issue 839": "PATCHES/hrinfo-839.patch"

--- a/html/sites/all/modules/contrib/i18n/i18n.module
+++ b/html/sites/all/modules/contrib/i18n/i18n.module
@@ -638,5 +638,33 @@ function i18n_entity_translation_enabled($entity_type) {
  * Implements hook_modules_enabled().
  */
 function i18n_modules_enabled($modules) {
+  i18n_object_info_cache_clear();
+}
+
+/**
+ * Implements hook_modules_installed().
+ */
+function i18n_modules_installed($modules) {
+  i18n_object_info_cache_clear();
+}
+
+/**
+ * Helper to clear relevant caches.
+ */
+function i18n_object_info_cache_clear() {
+  drupal_static_reset('i18n_get_object');
   drupal_static_reset('i18n_object_info');
+  drupal_static_reset('entity_i18n_controller');
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function i18n_module_implements_alter(&$implementations, $hook) {
+  if (($hook == 'modules_installed') || ($hook == 'modules_enabled')) {
+    // We must be the first in both hooks.
+    $group = $implementations['i18n'];
+    unset($implementations['i18n']);
+    $implementations = ['i18n' => $group] + $implementations;
+  }
 }


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/HRINFO-1029 

https://www.drupal.org/project/i18n/issues/2082573 suggests the error was caused by a module being enabled on the live site (which is why it's not common) and the solution is `drush rr`. That seemed to fix it, and this patch should mean we don't see it again.