### PR TITLE
[OPS-7193][OPS-7265] Bump HR.info to the current PHP 7.3.26 develop base image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM unocha/php7-k8s:${TAG:-7.3-NR-stable}
+FROM unocha/php7-k8s:${TAG:-7.3-NR-develop}
 
 ARG VCS_REF
 ARG VCS_URL
@@ -28,6 +28,4 @@ COPY ./docker/custom /etc/nginx/custom
 
 RUN  cd /srv/www/html/sites && \
        rm -f www.humanitarianresponse.info && \
-       ln -s default www.humanitarianresponse.info && \
-     apk add -U ghostscript freetype fontconfig && \
-     rm -rf /var/cache/apk/*
+       ln -s default www.humanitarianresponse.info


### PR DESCRIPTION
* Try to improve memcached serialize() performance via igbinary.
* Contains a working imagemagick + ghostscript for PDF previews.