### PR TITLE
[HRINFO-1034] allow access to revisions for admins

### DIFF
--- a/html/sites/all/modules/hr/hr_bundles/hr_bundles.module
+++ b/html/sites/all/modules/hr/hr_bundles/hr_bundles.module
@@ -205,6 +205,9 @@ function hr_bundles_form_node_form_alter(&$form, &$form_state) {
  * See http://atrium.humanitarianresponse.info/humanitarian_response/node/4363
  */
 function hr_bundles_node_access($node, $op, $account) {
+  if (in_array('administrator', $account->roles)) {
+    return NODE_ACCESS_IGNORE;
+  }
   if (isset($node->nid) && isset($node->{OG_AUDIENCE_FIELD}) && !empty($node->{OG_AUDIENCE_FIELD}) && isset($node->field_bundles) && ($op == 'update' || $op == 'delete')) {
     // Get the group id.
     $gid = $node->{OG_AUDIENCE_FIELD}[LANGUAGE_NONE][0]['target_id'];


### PR DESCRIPTION
As part of https://humanitarian.atlassian.net/browse/HRINFO-1034, discovered that admins don't have the access to see revisions for node type hr_page - and perhaps others as well.

This PR gives that access to admins, putting now on the staging site so at least admins can look there to see what's going on. It might need some more changing and fine-tuning.