### PR TITLE
Hrinfo 1037 ar update

### DIFF
--- a/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.info
+++ b/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.info
@@ -2,3 +2,6 @@ name = OCHA Assessments
 description = OCHA Assessments integration
 core = 7.x
 package = OCHA
+
+files[] = views/handlers/ocha_assessments_handler_field.inc
+files[] = views/plugins/ocha_assessments_plugin_query.inc

--- a/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.module
+++ b/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.module
@@ -125,7 +125,7 @@ function ocha_assessments_base_url() {
 /**
  * Basic Auth.
  */
-function ocha_assessments_basis_auth() {
+function ocha_assessments_basic_auth() {
   return variable_get('ocha_assessments_basic_auth', '');
 }
 
@@ -155,7 +155,7 @@ function ocha_assessments_operation_map($node) {
  */
 function ocha_assessments_list($location_id = NULL) {
   $base_url = ocha_assessments_base_url();
-  $basic_auth = ocha_assessments_basis_auth();
+  $basic_auth = ocha_assessments_basic_auth();
   $src = $base_url . '/rest/list-data';
 
   if ($location_id) {
@@ -177,7 +177,7 @@ function ocha_assessments_list($location_id = NULL) {
  */
 function ocha_assessments_table($location_id = NULL) {
   $base_url = ocha_assessments_base_url();
-  $basic_auth = ocha_assessments_basis_auth();
+  $basic_auth = ocha_assessments_basic_auth();
   $src = $base_url . '/rest/table-data';
 
   if ($location_id) {
@@ -199,7 +199,7 @@ function ocha_assessments_table($location_id = NULL) {
  */
 function ocha_assessments_map($location_id = NULL) {
   $base_url = ocha_assessments_base_url();
-  $basic_auth = ocha_assessments_basis_auth();
+  $basic_auth = ocha_assessments_basic_auth();
   $src = $base_url . '/rest/map-data';
 
   if ($location_id) {

--- a/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.module
+++ b/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.module
@@ -6,6 +6,15 @@
  */
 
 /**
+ * Implements hook_views_api().
+ */
+function ocha_assessments_views_api() {
+  return array(
+    'api' => 3.0,
+  );
+}
+
+/**
  * Implements hook_menu().
  */
 function ocha_assessments_menu() {

--- a/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views.inc
@@ -12,7 +12,7 @@ function ocha_assessments_views_plugins() {
   $plugin = array();
   $plugin['query']['ocha_assessments_plugin_query'] = array(
     'title' => t('Assessment Registry Query'),
-    'handler' => 'ocha_assessments_plugin_query',
+    'handler' => 'OchaAssessmentsPluginQuery',
   );
 
   return $plugin;
@@ -35,7 +35,7 @@ function ocha_assessments_views_data() {
   $data['ocha_assessments']['title'] = array(
     'title' => t('Title'),
     'field' => array(
-      'handler' => 'ocha_assessments_handler_field',
+      'handler' => 'OchaAssessmentsHandlerField',
     ),
   );
 

--- a/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views.inc
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Views plugin for Assessment Registry.
+ */
+
+/**
+ * Implements hook_views_plugins().
+ */
+function ocha_assessments_views_plugins() {
+  $plugin = array();
+  $plugin['query']['ocha_assessments_plugin_query'] = array(
+    'title' => t('Assessment Registry Query'),
+    'handler' => 'ocha_assessments_plugin_query',
+  );
+
+  return $plugin;
+}
+
+/**
+ * Implements hook_views_data().
+ */
+function ocha_assessments_views_data() {
+  $data = array();
+
+  $data['ocha_assessments']['table']['group'] = t('OCHA Assessments');
+  $data['ocha_assessments']['table']['base'] = array(
+    'title' => t('OCHA Assessments'),
+    'help' => t('Data from Assessment Registry'),
+    'query class' => 'ocha_assessments_plugin_query',
+  );
+
+  // Fields.
+  $data['ocha_assessments']['title'] = array(
+    'title' => t('Title'),
+    'field' => array(
+      'handler' => 'ocha_assessments_handler_field',
+    ),
+  );
+
+  return $data;
+}

--- a/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views_default.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views_default.inc
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @file
+ * ocha_assessments.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function ochochaassessments_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'assessments_from_registry';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'ocha_assessments';
+  $view->human_name = 'Assessments from Registry';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Latest Assessments';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '5';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['pager']['options']['quantity'] = '9';
+  $handler->display->display_options['style_plugin'] = 'list';
+  $handler->display->display_options['row_plugin'] = 'fields';
+  /* Field: OCHA Assessments: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'ocha_assessments';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+
+  /* Display: Content pane */
+  $handler = $view->new_display('panel_pane', 'Content pane', 'panel_pane_1');
+  $handler->display->display_options['pane_category']['name'] = 'OCHA_Assessments';
+  $handler->display->display_options['pane_category']['weight'] = '0';
+  $handler->display->display_options['allow']['use_pager'] = 0;
+  $handler->display->display_options['allow']['items_per_page'] = 0;
+  $handler->display->display_options['allow']['offset'] = 0;
+  $handler->display->display_options['allow']['link_to_view'] = 0;
+  $handler->display->display_options['allow']['more_link'] = 0;
+  $handler->display->display_options['allow']['path_override'] = 0;
+  $handler->display->display_options['allow']['title_override'] = 0;
+  $handler->display->display_options['allow']['exposed_form'] = 0;
+  $handler->display->display_options['allow']['fields_override'] = 0;
+  $translatables['assessments_from_registry'] = array(
+    t('Master'),
+    t('Latest Assessments'),
+    t('more'),
+    t('Apply'),
+    t('Reset'),
+    t('Sort by'),
+    t('Asc'),
+    t('Desc'),
+    t('Items per page'),
+    t('- All -'),
+    t('Offset'),
+    t('« first'),
+    t('‹ previous'),
+    t('next ›'),
+    t('last »'),
+    t('Content pane'),
+    t('OCHA_Assessments'),
+  );
+  $export['assessments_from_registry'] = $view;
+
+  return $export;
+}

--- a/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views_default.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/ocha_assessments.views_default.inc
@@ -8,7 +8,7 @@
 /**
  * Implements hook_views_default_views().
  */
-function ochochaassessments_views_default_views() {
+function ocha_assessments_views_default_views() {
   $export = array();
 
   $view = new view();

--- a/html/sites/all/modules/custom/ocha_assessments/views/handlers/ocha_assessments_handler_field.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/views/handlers/ocha_assessments_handler_field.inc
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Views field handler for Assessment Registry fields.
+ */
+
+/**
+ * Views field handler for Assessment Registry fields.
+ */
+class ocha_assessments_handler_field extends views_handler_field {
+
+  /**
+   * Set field_alias and avoid sql-specific query functionality.
+   */
+  function query() {
+    $this->field_alias = $this->real_field;
+  }
+
+  /**
+   * Return an html link, not plain text.
+   */
+  function render($values) {
+    return $values->title;
+  }
+
+}

--- a/html/sites/all/modules/custom/ocha_assessments/views/handlers/ocha_assessments_handler_field.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/views/handlers/ocha_assessments_handler_field.inc
@@ -8,19 +8,19 @@
 /**
  * Views field handler for Assessment Registry fields.
  */
-class ocha_assessments_handler_field extends views_handler_field {
+class OchaAssessmentsHandlerField extends views_handler_field {
 
   /**
    * Set field_alias and avoid sql-specific query functionality.
    */
-  function query() {
+  public function query() {
     $this->field_alias = $this->real_field;
   }
 
   /**
    * Return an html link, not plain text.
    */
-  function render($values) {
+  public function render($values) {
     return $values->title;
   }
 

--- a/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
@@ -43,9 +43,9 @@ class OchaAssessmentsPluginQuery extends views_plugin_query {
 
     $limit = variable_get('ocha_assessments_panel_display_limit', 5);
     $base_url = ocha_assessments_base_url();
-    $src = $base_url . '/rest/list-data';
+    $src = $base_url . '/rest/list-data?sort=-field_date';
     if (!empty($filters)) {
-      $src .= '?' . $filters;
+      $src .= '&' . $filters;
     }
 
     $request = drupal_http_request($src);

--- a/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
@@ -8,12 +8,12 @@
 /**
  * Views query plugin for Assessment Registry.
  */
-class ocha_assessments_plugin_query extends views_plugin_query {
+class OchaAssessmentsPluginQuery extends views_plugin_query {
 
   /**
    * Override query.
    */
-  function query($get_count = FALSE) {
+  public function query($get_count = FALSE) {
   }
 
   /**
@@ -23,7 +23,7 @@ class ocha_assessments_plugin_query extends views_plugin_query {
    * When changing to get the data from AR, only one operation using the
    * Assessments block was not country-based. There's no match to spaces on AR.
    */
-  function execute(&$view) {
+  public function execute(&$view) {
     $node = menu_get_object();
     if (empty($node)) {
       return;

--- a/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
@@ -31,24 +31,21 @@ class ocha_assessments_plugin_query extends views_plugin_query {
     $filters = '';
     switch ($node->type) {
       case 'hr_bundle':
-        $filters .= 'f[0]=clusters_sectors:' . $node->nid;
+        // @todo This isn't working. Need to add local_groups to AR.
+        // @codingStandardsIgnoreLine
+        //$filters .= 'f[0]=clusters_sectors:' . $node->nid;
         break;
 
       case 'hr_operation':
-        if (!empty($node->field_country[LANGUAGE_NONE])) {
-          $filters .= 'f[0]=locations:' . $node->field_country[LANGUAGE_NONE][0]['target_id'];
-        }
-        else {
-          return;
-        }
+        $filters .= 'f[0]=operation_id:' . $node->nid;
         break;
     }
 
     $limit = variable_get('ocha_assessments_panel_display_limit', 5);
     $base_url = ocha_assessments_base_url();
-    $src = $base_url . '/rest/assessments?items_per_page=' . $limit;
+    $src = $base_url . '/rest/list-data';
     if (!empty($filters)) {
-      $src .= '&' . $filters;
+      $src .= '?' . $filters;
     }
 
     $request = drupal_http_request($src);
@@ -56,9 +53,11 @@ class ocha_assessments_plugin_query extends views_plugin_query {
       $response = drupal_json_decode($request->data);
       if (!empty($response['search_results'])) {
         $options = array('external' => TRUE);
-        foreach ($response['search_results'] as $item) {
+        // @todo Add limit to api query when we can.
+        $results = array_slice($response['search_results'], 0, $limit);
+        foreach ($results as $item) {
           $row = new stdClass();
-          $row->title = l($item['title'], $base_url . '/node/' . $item['nid'], $options);
+          $row->title = l(reset($item['title']), $base_url . '/assessment/' . reset($item['uuid']), $options);
           $view->result[] = $row;
         }
       }

--- a/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file
+ * Views query plugin for Assessment Registry.
+ */
+
+/**
+ * Views query plugin for Assessment Registry.
+ */
+class ocha_assessments_plugin_query extends views_plugin_query {
+
+  /**
+   * Override query.
+   */
+  function query($get_count = FALSE) {
+  }
+
+  /**
+   * Get results.
+   *
+   * Only for hr_bundle and hr_operation - by country.
+   * When changing to get the data from AR, only one operation using the
+   * Assessments block was not country-based. There's no match to spaces on AR.
+   */
+  function execute(&$view) {
+    $node = menu_get_object();
+    if (empty($node)) {
+      return;
+    }
+    $filters = '';
+    switch ($node->type) {
+      case 'hr_bundle':
+        $filters .= 'f[0]=clusters_sectors:' . $node->nid;
+        break;
+
+      case 'hr_operation':
+        if (!empty($node->field_country[LANGUAGE_NONE])) {
+          $filters .= 'f[0]=locations:' . $node->field_country[LANGUAGE_NONE][0]['target_id'];
+        }
+        else {
+          return;
+        }
+        break;
+    }
+
+    $limit = variable_get('ocha_assessments_panel_display_limit', 5);
+    $base_url = ocha_assessments_base_url();
+    $src = $base_url . '/rest/assessments?items_per_page=' . $limit;
+    if (!empty($filters)) {
+      $src .= '&' . $filters;
+    }
+
+    $request = drupal_http_request($src);
+    if (isset($request->data)) {
+      $response = drupal_json_decode($request->data);
+      if (!empty($response['search_results'])) {
+        $options = array('external' => TRUE);
+        foreach ($response['search_results'] as $item) {
+          $row = new stdClass();
+          $row->title = l($item['title'], $base_url . '/node/' . $item['nid'], $options);
+          $view->result[] = $row;
+        }
+      }
+    }
+  }
+
+}

--- a/html/sites/all/modules/hr/hr_assessments/hr_assessments.module
+++ b/html/sites/all/modules/hr/hr_assessments/hr_assessments.module
@@ -26,7 +26,7 @@ function hr_assessments_og_features_registry() {
 }
 
 /**
- * Implementation of hook_entity_info_alter().
+ * Implements hook_entity_info_alter().
  */
 function hr_assessments_entity_info_alter(&$entity_info) {
   // Quick links.
@@ -131,7 +131,7 @@ function hr_assessments_field_widget_form_alter(&$element, &$form_state, $contex
         if (is_numeric($tid)) {
           $option_label = array();
           $parents = taxonomy_get_parents_all($tid);
-          foreach ($parents as $parent_id => $parent) {
+          foreach ($parents as $parent) {
             array_unshift($option_label, entity_label('taxonomy_term', $parent));
           }
           $option = implode(' > ', $option_label);
@@ -143,7 +143,7 @@ function hr_assessments_field_widget_form_alter(&$element, &$form_state, $contex
 }
 
 /**
- * Implements hook_clone_node_alter.
+ * Implements hook_clone_node_alter().
  */
 function hr_assessments_clone_node_alter(&$node, $context) {
   if ($node->type != 'hr_assessment') {

--- a/html/sites/all/modules/hr/hr_bundles/hr_bundles.panelizer.inc
+++ b/html/sites/all/modules/hr/hr_bundles/hr_bundles.panelizer.inc
@@ -105,36 +105,6 @@ function hr_bundles_panelizer_defaults() {
   $display->content['new-95e3e805-0870-4575-b617-cec3ea15411d'] = $pane;
   $display->panels['column1'][1] = 'new-95e3e805-0870-4575-b617-cec3ea15411d';
   $pane = new stdClass();
-  $pane->pid = 'new-b6ec1f94-7313-4b3a-ba67-c5b2145a3674';
-  $pane->panel = 'column1';
-  $pane->type = 'views_panes';
-  $pane->subtype = 'hr_assessments_panes-panel_pane_1';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'more_link' => 0,
-    'use_pager' => 0,
-    'pager_id' => '0',
-    'items_per_page' => '5',
-    'context' => array(
-      1 => 'panelizer',
-    ),
-    'override_title' => 0,
-    'override_title_text' => '',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-    'style' => 'hr_highlighted',
-  );
-  $pane->css = array();
-  $pane->extras = array();
-  $pane->position = 3;
-  $pane->locks = array();
-  $pane->uuid = 'b6ec1f94-7313-4b3a-ba67-c5b2145a3674';
-  $display->content['new-b6ec1f94-7313-4b3a-ba67-c5b2145a3674'] = $pane;
-  $display->panels['column1'][3] = 'new-b6ec1f94-7313-4b3a-ba67-c5b2145a3674';
-  $pane = new stdClass();
   $pane->pid = 'new-72991a33-ae33-4088-adbf-5f8b348b0e45';
   $pane->panel = 'column2';
   $pane->type = 'views_panes';

--- a/html/sites/all/modules/hr/hr_core/hr_core.module
+++ b/html/sites/all/modules/hr/hr_core/hr_core.module
@@ -1298,8 +1298,13 @@ function hr_core_ctools_content_subtype_alter(&$subtype, &$plugin) {
     'assessments' => array(
       'category' => 'Content by HR.info',
     ),
+    'ar_assessments' => array(
+      'category' => 'Content from AR',
+      'title' => 'Assessments from Registry',
+    ),
     'ocha_assessments' => array(
       'category' => 'Content from AR',
+      'title' => 'Assessments from Registry',
     ),
 
     // Outdated.

--- a/html/sites/all/modules/hr/hr_core/hr_core.module
+++ b/html/sites/all/modules/hr/hr_core/hr_core.module
@@ -1219,15 +1219,6 @@ function hr_core_ctools_content_subtype_alter(&$subtype, &$plugin) {
       'title' => 'Free text',
     ),
 
-    'hid_profiles_checkins' => array(
-      'category' => 'Contacts by HID',
-      'title' => 'Checkin',
-    ),
-    'hid_profiles_list' => array(
-      'category' => 'Contacts by HID',
-      'title' => 'Contacts',
-    ),
-
     // Documents.
     'documents' => array(
       'category' => 'Content by HR.info',
@@ -1307,6 +1298,9 @@ function hr_core_ctools_content_subtype_alter(&$subtype, &$plugin) {
     'assessments' => array(
       'category' => 'Content by HR.info',
     ),
+    'ocha_assessments' => array(
+      'category' => 'Content from AR',
+    ),
 
     // Outdated.
     'bean_pane' => array(
@@ -1354,6 +1348,8 @@ function hr_core_ctools_content_subtype_alter(&$subtype, &$plugin) {
   if (isset($plugin['name']) && $plugin['name'] == 'views_panes') {
     if (is_array($subtype['category'])) {
       $key = strtolower($subtype['category'][0]);
+      // @todo Check if key ever needs translating.
+      // @codingStandardsIgnoreLine
       if (array_key_exists(t($key), $categories)) {
         $plugin['category'] = $categories[$key]['category'];
         $subtype['category'] = $categories[$key]['category'];
@@ -1647,6 +1643,7 @@ function hr_core_node_validate($node, $form, &$form_state) {
  */
 function hr_core_form_taxonomy_form_term_alter(&$form, &$form_state, $form_id) {
 
+  // @codingStandardsIgnoreLine
   if ((!isset($form_state['input']['op']) || $form_state['input']['op'] != 'Delete')) {
     $form['#validate'][] = 'hr_core_validate_organization';
   }

--- a/html/sites/all/modules/hr/hr_operations/hr_operations.strongarm.inc
+++ b/html/sites/all/modules/hr/hr_operations/hr_operations.strongarm.inc
@@ -219,13 +219,12 @@ function hr_operations_strongarm() {
     'hr_reliefweb_ocha_products-hr_reliefweb_ocha_products' => TRUE,
     'twitter-twitter' => TRUE,
     'fieldable_panels_pane-fieldable_panels_pane' => TRUE,
-    'fieldable_panels_pane-hr_assessments' => TRUE,
-    'views_panes-hr_assessments_panes-list' => TRUE,
     'views_panes-hr_events_panes-upcoming' => TRUE,
     'views_panes-hr_events_panes-upcoming_from_context' => TRUE,
     'views_panes-hr_news_panes-list' => TRUE,
     'views_panes-hr_documents_panes-list' => TRUE,
     'views_panes-hr_infographics_panes-list' => TRUE,
+    'views_panes-assessments_from_registry-panel_pane_1' => TRUE,
   );
   $export['panelizer_node:hr_operation_allowed_types'] = $strongarm;
 


### PR DESCRIPTION
This adds a view for pane pulling assessments from AR. 

At the moment it only works for operations, we need to add a way to filter by 'local_groups' (clusters/sectors) to the AR api. Requires `drush fr hr_operations` for editors to be allowed to add it in panelizer. 

The pane is very basic and not configurable.

The results are different from the current pane as the sort order is different.

This should be fine to go with the deployment tomorrow - (i.e. feel free to merge it directly) but will need some tweaks afterwards. And to make the pane available for hr_bundles when we can (there are 6 operations currently using the assessments pane but nearly 500 bundles).