### PR TITLE
[HRINFO-1037] adjust structure of expected api results

### DIFF
--- a/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
+++ b/html/sites/all/modules/custom/ocha_assessments/views/plugins/ocha_assessments_plugin_query.inc
@@ -53,7 +53,7 @@ class OchaAssessmentsPluginQuery extends views_plugin_query {
         $results = array_slice($response['search_results'], 0, $limit);
         foreach ($results as $item) {
           $row = new stdClass();
-          $row->title = l(reset($item['title']), $base_url . '/assessment/' . reset($item['uuid']), $options);
+          $row->title = l($item['title'], $base_url . '/assessment/' . $item['uuid'], $options);
           $view->result[] = $row;
         }
       }


### PR DESCRIPTION
As noted in https://humanitarian.atlassian.net/browse/HRINFO-1047 the assessments blocks are empty.

This is due to a change in structure of the AR API results. This fixes it.