### PR TITLE
[HRINFO-1057] remove redirection for files with no alias

### DIFF
--- a/PATCHES/hrinfo-1057-file-alias-redirection.patch
+++ b/PATCHES/hrinfo-1057-file-alias-redirection.patch
@@ -1,0 +1,16 @@
+diff --git a/path_alias_xt.module b/path_alias_xt.module
+index 693ebc1..ca7947c 100755
+--- a/path_alias_xt.module
++++ b/path_alias_xt.module
+@@ -106,6 +106,11 @@ function path_alias_xt_url_inbound_alter(&$path, $original_path, $path_language)
+       }
+       array_unshift($path_suffix, array_pop($parts));
+       $candidate_alias = implode('/', $parts);
++      // @todo See HRINFO-1057. All files without an alias get redirected to a
++      // different file (which then gets cached). This avoids that situation.
++      if ($candidate_alias === 'file') {
++        return;
++      }
+       if ($src = drupal_lookup_path('source', $candidate_alias, $path_language)) {
+         // If 'user' is aliased to MyAccount, then MyAccount/edit needs to
+         // transform to 'user/123/edit'.

--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,7 @@
         "drupal/panels": "^3.9",
         "drupal/panels_bootstrap_layouts": "^3.0+12-dev",
         "drupal/panels_bootstrap_styles": "^1.0",
-        "drupal/path_alias_xt": "^1.2",
+        "drupal/path_alias_xt": "^1.3",
         "drupal/path_redirect_import": "^1.0-rc4",
         "drupal/pathauto": "^1.3",
         "drupal/pdfpreview": "^2.x-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0e47d3bcce29cd952bd61d677f3eba8",
+    "content-hash": "e714855d2243e47caea5cc60167e760f",
     "packages": [
         {
             "name": "composer/installers",
@@ -7126,6 +7126,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "HRINFO-1057 file alias redirection": "PATCHES/hrinfo-1057-file-alias-redirection.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/7/downloads",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -44,6 +44,9 @@
       "drupal/panels": {
         "Stop logs caused by https://www.drupal.org/project/panels/issues/3032350#comment-13075861": "PATCHES/panels-style-settings-default.patch"
       },
+      "drupal/path_alias_xt": {
+        "HRINFO-1057 file alias redirection": "PATCHES/hrinfo-1057-file-alias-redirection.patch"
+      },
       "drupal/pdfpreview": {
         "HRINFO-1035 filemtime errors": "PATCHES/hrinfo-1035-pdfpreview-filemtime-error.patch"
       },

--- a/html/sites/all/modules/contrib/path_alias_xt/path_alias_xt.module
+++ b/html/sites/all/modules/contrib/path_alias_xt/path_alias_xt.module
@@ -106,6 +106,11 @@ function path_alias_xt_url_inbound_alter(&$path, $original_path, $path_language)
       }
       array_unshift($path_suffix, array_pop($parts));
       $candidate_alias = implode('/', $parts);
+      // @todo See HRINFO-1057. All files without an alias get redirected to a
+      // different file (which then gets cached). This avoids that situation.
+      if ($candidate_alias === 'file') {
+        return;
+      }
       if ($src = drupal_lookup_path('source', $candidate_alias, $path_language)) {
         // If 'user' is aliased to MyAccount, then MyAccount/edit needs to
         // transform to 'user/123/edit'.


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/HRINFO-1057

Files without a path alias (we could open another ticket to work out *why* they don't have an alias) are all getting redirected to the same file.
Turns out this is caused by the `path_alias_xt` module (we could also have another ticket to remove that module - it turns 'edit' links etc into path aliases, which, for me, just makes it harder to discover the node number. Not sure if there are any benefits).
This adds a patch to stop looking for path aliases when it hasn't already found one and the path begins with 'file'.