### PR TITLE
[SCS-68] restore alternatively named spatial_import module

### DIFF
--- a/html/sites/all/modules/contrib/spatial_import/spatial_import.feeds.ShapefileParser.inc
+++ b/html/sites/all/modules/contrib/spatial_import/spatial_import.feeds.ShapefileParser.inc
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @file
+ * Parses a given file as a zipped shapefile.
+ */
+class SpatialImportShapefileParser extends FeedsParser {
+
+  /**
+   * Parses a raw string and returns a Feed object from it.
+   */
+  public function parse(FeedsSource $source, FeedsFetcherResult $fetcher_result) {
+    $options = $source->getConfigFor($this);
+    $filepath = $fetcher_result->getFilePath();
+    $shapefile_data = spatial_import_process_shapefile($filepath, $this->config['spatial_field_name'], 'wkt');
+    // Apply titles in lower case.
+    foreach ($shapefile_data['columns'] as $i => $title) {
+      $shapefile_data['columns'][$i] = strtolower($title); // Use lower case only.
+    }
+    $result_rows = array();
+    foreach ($shapefile_data['data'] as $i => $row) {
+      $result_row = array();
+      foreach ($row as $j => $col) {
+        $result_row[$shapefile_data['columns'][$j]] = trim($col);
+      }
+      $result_rows[] = $result_row;
+    }
+    // Return result.
+    return new FeedsParserResult($result_rows, $source->feed_nid);
+  }
+
+  /**
+   * Override parent::getMappingSources().
+   */
+  public function getMappingSources() {
+    return FALSE;
+  }
+
+  /**
+   * Override parent::getSourceElement() to use only lower keys.
+   */
+  public function getSourceElement(FeedsSource $source, FeedsParserResult $result, $element_key) {
+    return parent::getSourceElement($source, $result, drupal_strtolower($element_key));
+  }
+
+  /**
+   * Define defaults.
+   */
+  public function sourceDefaults() {
+    return array();
+  }
+
+  /**
+   * Source form.
+   *
+   * Show mapping configuration as a guidance for import form users.
+   */
+  public function sourceForm($source_config) {
+    $form = array();
+    $form['#weight'] = -10;
+
+    $mappings = feeds_importer($this->id)->processor->config['mappings'];
+    $sources = $uniques = array();
+    foreach ($mappings as $mapping) {
+      $sources[] = $mapping['source'];
+      if ($mapping['unique']) {
+        $uniques[] = $mapping['source'];
+      }
+    }
+
+    $output = t('Import zipped !shapefile with one or more of these columns: !columns.', array('!shapefile' => l(t('Shapefiles'), 'http://en.wikipedia.org/wiki/Shapefile'), '!columns' => implode(', ', $sources)));
+    $items = array();
+    $items[] = format_plural(count($uniques), t('Column <strong>!column</strong> is mandatory and considered unique: only one item per !column value will be created.', array('!column' => implode(', ', $uniques))), t('Columns <strong>!columns</strong> are mandatory and values in these columns are considered unique: only one entry per value in one of these column will be created.', array('!columns' => implode(', ', $uniques))));
+    
+    $form['help'] = array(
+      '#prefix' => '<div class="help">',
+      '#suffix' => '</div>',
+      'description' => array(
+        '#prefix' => '<p>',
+        '#markup' => $output,
+        '#suffix' => '</p>',
+      ),
+      'list' => array(
+        '#theme' => 'item_list',
+        '#items' => $items,
+      ),
+    );
+
+    return $form;
+  }
+
+  /**
+   * Define default configuration.
+   */
+  public function configDefaults() {
+    return array(
+      'spatial_field_name' => 'geom',
+      'srid' => '4326',
+      'storage' => 'wkt',
+    );
+  }
+
+  /**
+   * Build configuration form.
+   */
+  public function configForm(&$form_state) {
+    $form = array();
+    $form['spatial_field_name'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Spatial Data Column'),
+      '#default_value' => $this->config['spatial_field_name'],
+      '#size' => 24,
+      '#maxlength' => 24,
+      '#description' => t('Shapefiles do not contain a geometry \'column\'. Please specify the a name for the column where the geometry will be stored. This column can then be referenced by \'Name of source field\' in field mappings.')
+    );
+    $form['srid'] = array(
+      '#type' => 'textfield',
+      '#title' => t('SRID (Spatial projection)'),
+      '#default_value' => $this->config['srid'],
+      '#size' => 24,
+      '#maxlength' => 24,
+      '#description' => t('Integer represeting the SRID of the uploaded shapefile. If you are unsure, use \'4326\' (lat/lon).')
+    );
+    $form['storage'] = array(
+      '#type' => 'hidden',
+      '#title' => t('Database Storage'),
+      '#value' => 'wkt',
+      '#required' => TRUE,
+    );
+    return $form;
+  }
+}

--- a/html/sites/all/modules/contrib/spatial_import/spatial_import.feeds.inc
+++ b/html/sites/all/modules/contrib/spatial_import/spatial_import.feeds.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Implements Hook.
+ */
+
+
+/**
+ * Implements hook_feeds_plugins().
+ *
+ * Declare to Feeds that we have a parser plugin that it can use.
+ */
+function spatial_import_feeds_plugins() {
+  $path = drupal_get_path('module', 'spatial_import');
+  $info = array();
+  $info['SpatialImportShapefileParser'] = array(
+    'name' => 'Shapefile parser',
+    'description' => 'Parse data in zipped shapefile format.',
+    'handler' => array(
+      'parent' => 'FeedsParser',
+      'class' => 'SpatialImportShapefileParser',
+      'file' => 'spatial_import.feeds.ShapefileParser.inc',
+      'path' => $path,
+    ),
+  );
+  return $info;
+}

--- a/html/sites/all/modules/contrib/spatial_import/spatial_import.info
+++ b/html/sites/all/modules/contrib/spatial_import/spatial_import.info
@@ -1,0 +1,4 @@
+name = Spatial Import
+description = Import spatial data with Table Wizard or Feeds
+package = Geo Spatial Tools
+core = 7.x

--- a/html/sites/all/modules/contrib/spatial_import/spatial_import.module
+++ b/html/sites/all/modules/contrib/spatial_import/spatial_import.module
@@ -1,0 +1,369 @@
+<?php
+// Include Feed hooks and functionality
+require_once(drupal_get_path('module', 'spatial_import') . '/spatial_import.feeds.inc');
+
+// Include Table Wizard hooks and functionality
+require_once(drupal_get_path('module', 'spatial_import') . '/spatial_import.tw.inc');
+
+/**
+ * Process Shapefile
+ *
+ * This is where the action happens. Given a path, get all the data out of a
+ * zipped shapefile.
+ */
+function spatial_import_process_shapefile($filepath, $spatial_field = 'geom', $field_type = 'wkt') {
+    if (!is_readable($filepath) || (!is_resource($zip = zip_open(drupal_realpath($filepath))))) {
+      drupal_set_message(t('zip file nonexistant or unreadable.'), 'error');
+      return;
+    }
+
+    // Catalog the contents of the zip file.
+    $files = array();
+    while ($res = zip_read($zip)) {
+      $ext = strtolower(substr(strrchr(zip_entry_name($res), '.'), 1));
+      $files[$ext] = $res;
+    }
+
+    // The zip file must minimally contain a shp, dbf and shx file.
+    if (!isset($files['shp']) || !isset($files['dbf']) || !isset($files['shx'])) {
+      drupal_set_message(t('This does not appear to be an archive that contains valid shp data.'), 'error');
+      return;
+    }
+
+    // See if we can get the projection information from the prj file.
+    if (isset($files['prj'])) {
+      // TODO Parse srid from prj file, for conversion if necessary.
+    }
+
+    if (isset($files['dbt'])) {
+      drupal_set_message(t('This database contains longtext/memo fields, which are unsupported.  Proceeding to enter other data anyway.'), 'warning');
+    }
+
+    // Get headers and table definition from the dbf file.
+    $schema = array('description' => t('Imported shapefile'), 'fields' => array());
+    $headers = _spatial_import_dbf_headers($files['dbf'], $schema);
+
+    // Shape file headers are stored in the first 100 bytes of the shp/shx files.
+    $headers += _spatial_import_shp_headers(zip_entry_read($files['shp'], 100));
+
+    // Apply 'direct to database' filters.
+    // These are only used by TW Import
+    $headers['field_filters'][$spatial_field] = '_spatial_import_shp_data_' . $field_type;
+
+    // Get column names
+    $columns = array_keys($headers['field_lengths']);
+
+     // Add 'spatial_field' to the list of columns
+    $columns[] = $spatial_field;
+
+    // Add spatial_field to schema
+    if ($field_type == 'geometry') {
+      $schema['fields'][$spatial_field] = array(
+        'type' => 'geometry',
+        'mysql_type' => 'geometry',
+        'pgsql_type' => 'GEOMETRY',
+        'not null' => TRUE,
+      );
+    }
+
+    if ($field_type == 'wkt') {
+      $schema['fields'][$spatial_field] = array(
+        'type' => 'text',
+        'size' => 'big',
+      );
+    }
+
+    $data = array();
+
+    $row_count = 0;
+    while ($shp = _spatial_import_shp_get_record($files['shp'])) {
+      $values = array();
+      $dbf_data = zip_entry_read($files['dbf'], $headers['record_size']);
+      $dbf_data = substr($dbf_data, 1); // Remove "record deleted" flag.
+      foreach ($headers['field_lengths'] as $name => $length) {
+        $value = substr($dbf_data, 0, $length);
+        $dbf_data = substr($dbf_data, $length);
+
+        // Use a predefined function to filter and process each value.
+        $process = $headers['field_filters'][$name];
+        $values[] = $value;
+      }
+
+      // Add the geometry text.
+      if (is_array($shp['data'])) {
+        $values[] = $shp['data']['wkt'];
+      }
+      else {
+        $values[] = $shp['data'];
+      }
+      $data[] = $values;
+
+      $row_count++;
+    }
+
+    return array(
+      'schema' => $schema,
+      'headers' => $headers,
+      'columns' => $columns,
+      'shapecolumn' => $spatial_field,
+      'shapetype' => $field_type,
+      'data' => $data,
+      'srid' => NULL, //@@TODO
+    );
+}
+
+
+/**
+ * Generate the Drupal-relative path for storing imported files (creating the spatial_imports
+ * directory if necessary).
+ */
+function _spatial_import_file_name($file) {
+  $dir = str_replace('\\', '/', getcwd()) . '/' . file_directory_path() . '/spatial_imports';
+  if (file_check_directory($dir, TRUE)) {
+    return $dir . '/' . $file;
+  }
+  else {
+    return FALSE;
+  }
+}
+
+function _spatial_import_shp_geo_types($key = NULL) {
+  $geo_types = array(
+    0 => 'none',
+    1 => 'point',
+    3 => 'linestring',  //TODO this is specified as 'polyline' in the standard.
+    5 => 'polygon',
+    8 => 'multipoint',
+    11 => 'pointz',
+    13 => 'polylinez',
+    15 => 'polygonz',
+    18 => 'multipointz',
+    21 => 'pointm',
+    23 => 'polylinem',
+    25 => 'polygonm',
+    28 => 'multipointm',
+    31 => 'multipatch',
+  );
+
+  if ($key) return $geo_types[$key];
+  return $geo_types;
+}
+
+function _spatial_import_dbf_headers(&$fp, &$schema) {
+
+  // Crack open the dbf file for processing.
+  $data = zip_entry_read($fp, 32);
+
+  // Set basic headers.
+  $headers = unpack('H2db_id/Cy/Cm/Cd/Lcount/Sheader_size/Srecord_size', $data);
+  $date = $headers['m'] . '/' . $headers['d'] . '/' . $headers['y'] + 1900;
+  $headers['date'] = strtotime($date);
+
+  // Get the remainder of the dbf headers.
+  $field_data = zip_entry_read($fp, $headers['header_size'] - 32);
+
+  $type_map = array(
+    'C' => 'char',
+    'N' => 'int',
+    'L' => 'int',
+    'D' => 'date',
+    'M' => 'text',
+    'F' => 'float',
+    'B' => 'blob',
+    'Y' => 'decimal',
+    'P' => 'blob',
+    'I' => 'int',
+    'Y' => 'decimal',
+    'T' => 'datetime',
+    'V' => 'varchar',
+    'X' => 'varchar',
+    '@' => 'timestamp',
+    '0' => 'decimal',
+    '+' => 'serial',
+  );
+
+  // Gather the column definitions from the field headers.
+  $mask = 'A11name/Atype/x4/Clength/Cprecision';
+  while (strlen($field_data) >= 32) {
+    $d = unpack($mask, $field_data);
+    $field_data = substr($field_data, 32);
+
+    // Field name.
+    $name = drupal_convert_to_utf8(strtolower(trim($d['name'])), 'ascii');
+    $name = preg_replace('/[^a-z0-9_]/', '', $name);
+
+    // Datatype.
+    $type = isset($type_map[$d['type']]) ? $type_map[$d['type']] : 'varchar';
+    if ($type == 'char' && $d['length'] > 3) $type = 'varchar';
+
+    // Default data processing function, which will escape and UTF8 convert.
+    $filter = '_spatial_import_shp_data_text';
+
+    // Use all-purpose PHP functions for standard numeric types.
+    if (in_array($type, array('float', 'decimal'))) $filter = 'floatval';
+    if (in_array($type, array('int', 'timestamp', 'serial'))) $filter = 'intval';
+    if ($type == 'date') $filter = '_spatial_import_shp_data_date';
+
+    // Special case for boolean, convert to int.
+    if ($d['type'] == 'L') $filter = '_spatial_import_shp_data_bool';
+
+    $headers['field_filters'][$name] = $filter;
+
+    // Datatype futzing.
+    $schema['fields'][$name] = array('type' => $type, 'length' => $d['length']);
+    if ($d['precision']) {
+      $schema['fields'][$name]['not null'] = TRUE;
+      $schema['fields'][$name]['default'] = 0.0;
+    }
+
+    // Remove precision from simple types.
+    if (in_array($type, array('int', 'float', 'real', 'timestamp'))) {
+      unset($schema['fields'][$name]['length']);
+    }
+
+    // Store field length for processing.
+    $headers['field_lengths'][$name] = $d['length'];
+  }
+
+  unset($headers['y'], $headers['m'], $headers['d'], $headers['header_size']);
+  return $headers;
+}
+
+
+// 'Direct to Datbase' format processors.  These functions escape and format
+// data for direct deposit into the database. They should be depreciated
+// as they are wide-open to SQL Injection attacks.  They are currently only
+// used by the TW importer, which must write it's own database records.
+
+function _spatial_import_shp_data_geometry($value) {
+  $value = db_escape_string(trim(drupal_convert_to_utf8($value, 'ascii')));
+  return "GeomFromText('$value')";
+}
+
+function _spatial_import_shp_data_wkt($value) {
+  $value = db_escape_string(trim(drupal_convert_to_utf8($value, 'ascii')));
+  return "'$value'";
+}
+
+function _spatial_import_shp_data_text($value) {
+  $value = db_escape_string(trim(drupal_convert_to_utf8($value, 'ascii')));
+  return "'$value'";
+}
+
+function _spatial_import_shp_data_bool($value) {
+  return (int) in_array($value, array('t', 'T', 'y', 'Y'));
+}
+
+function _spatial_import_shp_data_date($value) {
+  // Per the spec, we get the data in YYYYMMDD format.
+  $y = (int) substr($value, 0, 4);
+  $m = (int) substr($value, 4, 2);
+  $d = (int) substr($value, 6, 2);
+  return "'$y-$m-$d'";
+}
+
+
+
+function _spatial_import_shp_headers($data) {
+  $mask = 'x28/iversion/igeo_type/dmin_x/dmax_x/dmin_y/dmax_y/dmin_z/dmax_z/dmin_m/dmax_m';
+  $headers = unpack($mask, $data);
+  $headers['geo_type'] = _spatial_import_shp_geo_types($headers['geo_type']);
+  return $headers;
+}
+
+function _spatial_import_shp_get_record(&$fp) {
+  if (!$row_header = zip_entry_read($fp, 12)) return FALSE;
+
+  $row = unpack('Nnumber/Nlength/igeo_type', $row_header);
+
+  $row['geo_type'] = _spatial_import_shp_geo_types($row['geo_type']);
+
+  // Look for _spatial_import_shp_get_point(), _spatial_import_shp_get_linestring(), etc.
+  if (!function_exists($func = '_spatial_import_shp_get_' . $row['geo_type'])) {
+    drupal_set_message(t('Unsupported geo type %type found in file.', array('%type' =>  $row['geo_type'])), 'error');
+    return FALSE;
+  }
+
+  $row['data'] = $func($fp);
+  return $row;
+}
+
+function _spatial_import_spatial_import_shp_get_point_data(&$fp) {
+  $data = unpack('dx/dy', zip_entry_read($fp, 16));
+  return join(' ', $data);
+}
+
+function _spatial_import_shp_get_point(&$fp) {
+  return 'POINT(' . _spatial_import_spatial_import_shp_get_point_data($fp) . ')';
+}
+
+function _spatial_import_shp_get_linestring(&$fp) {
+  $data = array(
+    'bbox'  => unpack('dmin_x/dmin_y/dmax_x/dmax_y', zip_entry_read($fp, 32)),
+    'point_count' => current(unpack('i', zip_entry_read($fp, 4))),
+  );
+
+  $wkt = 'LINESTRING(';
+  for ($i = 1; $i <= $data['point_count']; $i++) {
+    $wkt .= _spatial_import_spatial_import_shp_get_point_data($fp) . ',';
+  }
+  $wkt = substr($wkt, 0, -1) . ')';
+
+  return $data;
+}
+
+function _spatial_import_shp_get_polygon(&$fp) {
+  $data = array(
+    'bbox'  => array(
+      'min_x' => _spatial_import_shp_data_fetch('d', $fp),
+      'min_y' => _spatial_import_shp_data_fetch('d', $fp),
+      'max_x' => _spatial_import_shp_data_fetch('d', $fp),
+      'max_y' => _spatial_import_shp_data_fetch('d', $fp),
+    ),
+    'part_count' => _spatial_import_shp_data_fetch('i', $fp),
+    'point_count' => _spatial_import_shp_data_fetch('i', $fp),
+  );
+
+  $wkt = '';
+
+  $points_counted = 0; $point_count; $last_offset = 0;
+  $parts = array();
+  for ($i = 0; $i < ($data['part_count']); $i++) {
+    $parts[] = _spatial_import_shp_data_fetch('i', $fp);
+  }
+
+  $points_counted = 0;
+  foreach ($parts as $i => $offset) {
+    if (isset($parts[$i+1])) {
+      $next_offset = $parts[$i+1];
+      $points_counted += $point_count = ($next_offset - $offset);
+    }
+    else {
+      $point_count = $data['point_count'] - $points_counted;
+    }
+
+    if (!$point_count) continue;
+
+    // Gather the point data for each part segment.
+    $wkt .= '(';
+    for ($j = 1; $j <= $point_count; $j++) {
+      $wkt .= _spatial_import_spatial_import_shp_get_point_data($fp) . ',';
+    }
+    $wkt = substr($wkt, 0, -1) . '),';
+  }
+  $data['wkt'] = 'POLYGON(' . substr($wkt, 0, -1) . ')';
+  return $data;
+}
+
+function _spatial_import_shp_data_fetch($type, &$fp, $offset = NULL) {
+  if (in_array($type, array('i', 'N'))) {
+    $length = 4;
+  }
+  elseif (in_array($type, array('d' ))) {
+    $length = 8;
+  }
+  if (is_string($fp)) {
+    return current(unpack($type, substr($fp, $offset, $length)));
+  }
+  return current(unpack($type, zip_entry_read($fp, $length)));
+}

--- a/html/sites/all/modules/contrib/spatial_import/spatial_import.tw.inc
+++ b/html/sites/all/modules/contrib/spatial_import/spatial_import.tw.inc
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * @file
+ * Implements Hook.
+ */
+
+/**
+ * Implements hook_tw_form().
+ *
+ * Declare to Table Wizard that we have an upload / import form that it can use.
+ */
+function spatial_import_tw_form() {
+  // Upload spatial files
+  $fieldsets['shapefile'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Upload spatial files'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    'uploadhelp' => array(
+      '#prefix' => '<div>',
+      '#value' => t('Uploading a new file imports the contents of the file into a database table and
+        adds it to the list above. Uploading a new copy of a previously-uploaded file replaces the
+        file data - it should be reanalyzed before doing anything further. Note that any existing
+        comments, ignored fields, and excluded rows are preserved when reloading the data.'),
+      '#suffix' => '</div>',
+    ),
+    'file' => array(
+      '#type' => 'file',
+      '#title' => t('Upload shapefile'),
+      '#size' => 48,
+      '#description' => t('File containing the data to be imported. Should be a zipped shapefile.'),
+    ),
+    'tablename' => array(
+      '#type' => 'textfield',
+      '#title' => t('Table name'),
+      '#size' => 64,
+      '#maxlength' => 64,
+      '#description' => t('Name of the database table to create from this file. If left blank,
+        the uploaded filename (without its extension) will be used to name the table. For example,
+        uploading <em>OldRecords.shp</em> will create the table <em>OldRecords</em>.')
+    ),
+    'spatial_field_name' => array(
+      '#type' => 'textfield',
+      '#title' => t('Spatial Data Column'),
+      '#default_value' => 'geom',
+      '#size' => 24,
+      '#maxlength' => 24,
+      '#description' => t('The database column name that the spatial data should be stored in.')
+    ),
+    'srid' => array(
+      '#type' => 'textfield',
+      '#title' => t('SRID (Spatial projection)'),
+      '#default_value' => '4326',
+      '#size' => 24,
+      '#maxlength' => 24,
+      '#description' => t('Integer represeting the SRID of the uploaded shapefile. If you are unsure, leave blank to use lat/lon (4326). ')
+    ),
+    'storage' => array(
+      '#type' => 'select',
+      '#title' => t('Database Storage'),
+      '#options' => array(
+        'wkt' => t('Well-Known-Text (Recommended)'),
+        'geometry' => t('Spatial Database Geometries (WKB)'),
+      ),
+      '#description' => t('Storage of this data may be stored either as raw text (<a href="http://en.wikipedia.org/wiki/Well-known_text">WKT</a>), or as spatial database geometries.'),
+      '#required' => TRUE,
+    ),
+    'spatialsubmit' => array(
+      '#type' => 'submit',
+      '#value' => t('Import shapefile'),
+    ),
+  );
+
+  return $fieldsets;
+}
+
+
+/**
+ * Implements hook_tw_form_submit().
+ *
+ * Process tw form data into a database table
+ */
+function spatial_import_tw_form_submit_shapefile($options) {
+  $file = file_save_upload('shapefile');
+  if ($file) {
+    // Move the uploaded file to the tw_delimited directory
+    $dest = _spatial_import_file_name($file->filename);
+    if ($dest) {
+      file_move($file, $dest, FILE_EXISTS_REPLACE);
+    }
+    else {
+      drupal_set_message(check_plain(t('Could not upload !filename', array('!filename' => ($file -> filename)))));
+      return;
+    }
+
+    // If an explicit table name was not provided...
+    if ($options['tablename']) {
+      $tablename = trim($options['tablename']);
+    }
+    else {
+      // ... Derive one from the filename (minus extension)
+      $pieces = explode('.', $file->filename);
+      $tablename = trim($pieces[0]);
+    }
+
+    if (!$tablename) {
+      drupal_set_message(check_plain(t('Could not derive a table name for !filename', array('!filename' => ($file -> filename)))));
+      return;
+    }
+
+    // Set SRID -- @@TODO: grab this from the shapfile
+    $srid = $options['srid'] ? $options['srid'] : '4326';
+
+    // Lowercase table names make views integration much easier
+    $tablename = drupal_strtolower(preg_replace('/[^a-z0-9]/i', '_', $tablename));
+
+    // Truncate to 63 characters (valid for either MySQL or Postgres)
+    $tablename = drupal_substr($tablename, 0, 63);
+
+    // Actually crunch the data from the shapefile and get the results.
+    $shapefile_data = spatial_import_process_shapefile($file->filepath, $options['spatial_field_name'], $options['storage']);
+
+    // TODO: Option to append instead of replace (i.e., skip the TRUNCATE)
+    if (db_table_exists($tablename)) {
+      if ($options['tablename']) {
+        db_query('DROP TABLE {' . $tablename . '}');
+        drupal_set_message(t('Replacing existing table'));
+        db_create_table($ret, $tablename, $shapefile_data['schema']);
+      }
+      else {
+          drupal_set_message(t('If you wish to replace an existing table, you must specify the table name explicitly', 'error'));
+          return;
+      }
+    }
+    else {
+      // Note that when using table prefixes, a prefix is prepended to the table name
+      db_create_table($ret, $tablename, $shapefile_data['schema']);
+    }
+    // If we want to store things as geometries, then we should create a spatial index.
+    // @@TODO: Add to 'spatial columns' in postGIS
+    if ($options['storage'] == 'geometry') {
+      $field = $options['spatial_field_name'];
+      switch ($GLOBALS['db_type']) {
+        case 'pgsql':
+          db_query("CREATE INDEX {" . $tablename . "}_" . $field . "_idx ON {" . $table . "} USING GIST ($field GIST_GEOMETRY_OPS)");
+          break;
+        case 'mysql':
+        case 'mysqli':
+          db_query("CREATE SPATIAL INDEX {$tablename}_${field}_idx ON  {" . $tablename . "} ($field)");
+          break;
+      }
+    }
+    // Import the data into the database
+    foreach ($shapefile_data['data'] as $row) {
+      $values = array();
+      foreach ($row as $key => $value) {
+        // Add quotes, and other nessisary cleanup
+        $callback = $shapefile_data['headers']['field_filters'][$shapefile_data['columns'][$key]];
+        $values[] = $callback($value);
+      }
+      // We've already handled sanitization of tablename, column names and
+      // values, so we're going to skip the substitutions.
+      db_query("INSERT INTO {$tablename} ( " . implode(', ', $shapefile_data['columns'] ) . ") VALUES (" . join(', ', $values) . ")");
+    }
+    // Load the results into our list of spatial tables
+    $spatial_import_tables = variable_get("spatial_import_tables", array());
+    $spatial_import_tables[$tablename] = array(
+      'table' => $tablename,
+      'field' => $options['spatial_field_name'],
+      'type' => $options['storage'],
+      'module' => 'tw',
+    );
+    variable_set("spatial_import_tables", $spatial_import_tables);
+    // Pass the table name back to Table Wizard
+    return array($tablename);
+  }
+  else {
+    drupal_set_message(t('Failed to upload spatial file'));
+  }
+}


### PR DESCRIPTION
Both spellings of spatial_import module, (with underscore and with hyphen) provoke warnings that the other is missing:
https://jenkins.aws.ahconu.org/view/HR.info/job/hrinfo-dev-deploy/120/console
https://jenkins.aws.ahconu.org/view/HR.info/job/hrinfo-dev-deploy/121/console

This restores the contrib module as it was, and includes the new one through composer. Feels like it needs a clearer resolution.