### PR TITLE
[OPS-7688] avoid ckeditor version warning

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,5 +1,8 @@
 {
     "patches": {
+      "drupal/cors": {
+        "#2280323: Sends Multiple Access-Control-Allow-Origin": "https://www.drupal.org/files/issues/sends_multiple-2280323-10.patch"
+      },
       "drupal/drupal": {
         "Extended Aliases core patch": "https://www.drupal.org/files/issues/2420275-1.patch",
         "Invalid node_load() parameters fix": "PATCHES/node_load_fix.patch",
@@ -12,8 +15,15 @@
         "HR.info issue 913": "PATCHES/hrinfo-913.patch",
         "HR.info issue 1025": "PATCHES/hrinfo-1025.date-popup.patch"
       },
+      "drupal/dbtng_migrator": {
+        "#2757035: Integrity constraint violation errors when migrating from Postgres to MySQL": "PATCHES/integrity-constraint-error-postgres-source-2757035-1-D7.patch",
+        "Skip deleted tables": "PATCHES/dbtng_migrator_skip_field_deleted.patch"
+      },
       "drupal/entity_api": {
         "Send entire node to node_access on create": "https://www.drupal.org/files/issues/2018-12-04/3017993-send_full_node.patch"
+      },
+      "drupal/facetapi_bonus": {
+        "Allow HTML in reset link": "https://www.drupal.org/files/issues/2020-08-26/2205469-allow_html-2.patch"
       },
       "drupal/fts": {
         "Quite a lof of local modifications": "PATCHES/fts-hacks.patch"
@@ -59,19 +69,12 @@
         "HRINFO-1035 undefined index": "PATCHES/hrinfo-1035-restful-undefined-index.patch",
         "OPS-7193 PSR-4 files not picked up": "PATCHES/ops-7193-include-restful-files.patch"
       },
-      "drupal/facetapi_bonus": {
-        "Allow HTML in reset link": "https://www.drupal.org/files/issues/2020-08-26/2205469-allow_html-2.patch"
-      },
-      "drupal/dbtng_migrator": {
-        "#2757035: Integrity constraint violation errors when migrating from Postgres to MySQL": "PATCHES/integrity-constraint-error-postgres-source-2757035-1-D7.patch",
-        "Skip deleted tables": "PATCHES/dbtng_migrator_skip_field_deleted.patch"
-      },
       "drupal/shs": {
         "Disable entity loading": "PATCHES/shs_lazyload.patch",
         "Disable entity loading 2": "PATCHES/shs_lazyload_2.patch"
       },
-      "drupal/cors": {
-        "#2280323: Sends Multiple Access-Control-Allow-Origin": "https://www.drupal.org/files/issues/sends_multiple-2280323-10.patch"
+      "drupal/wysiwyg": {
+        "Bump accepted ckeditor version": "https://www.drupal.org/files/issues/2021-08-12/ckeditorVersion4162-3227897-5.patch"
       }
     }
 }

--- a/html/sites/all/modules/contrib/wysiwyg/editors/ckeditor.inc
+++ b/html/sites/all/modules/contrib/wysiwyg/editors/ckeditor.inc
@@ -32,7 +32,7 @@ function wysiwyg_ckeditor_editor() {
       ),
     ),
     'install note callback' => 'wysiwyg_ckeditor_install_note',
-    'verified version range' => array('3.0', '4.16.1.cae20318d4'),
+    'verified version range' => array('3.0', '4.16.2.4e64f67219'),
     'migrate settings callback' => 'wysiwyg_ckeditor_migrate_settings',
     'version callback' => 'wysiwyg_ckeditor_version',
     'themes callback' => 'wysiwyg_ckeditor_themes',


### PR DESCRIPTION
Adds a patch to bump the accepted ckeditor version. And alphabeticizes the composer.json while we're there.