### PR TITLE
[OPS-7987] add PetalBot to bad bots list

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,4 +37,5 @@ COPY --from=builder /srv/www/docker/custom /etc/nginx/custom
 
 RUN  cd /srv/www/html/sites && \
        rm -f www.humanitarianresponse.info && \
-       ln -s default www.humanitarianresponse.info
+       ln -s default www.humanitarianresponse.info && \
+       sed -i 's/libwww-perl .\+1;/libwww-perl 1;\n    ~*PetalBot 1;/' /etc/nginx/blacklist.conf


### PR DESCRIPTION
I think it would be useful to have a simpler way to define bad bots and bad IPs. Not sure if I want to keep overwriting things from the stack or from the repo though. Seems so 2021ish. :)