### PR TITLE
[OPS-7459] configure warning times for user_expire module

### DIFF
--- a/html/sites/all/modules/hr/hr_users/hr_users.strongarm.inc
+++ b/html/sites/all/modules/hr/hr_users/hr_users.strongarm.inc
@@ -68,6 +68,20 @@ function hr_users_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'user_expire_warning_frequency';
+  $strongarm->value = 518400;
+  $export['user_expire_warning_frequency'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'user_expire_warning_offset';
+  $strongarm->value = 1209600;
+  $export['user_expire_warning_offset'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'user_pictures';
   $strongarm->value = 1;
   $export['user_pictures'] = $strongarm;


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/OPS-7459

Changes the warning time before a user is 'expired' to 14 days (from 7) and the gap between warnings to 6 days (from 2). These values might change again.