### PR TITLE
fix: Drop in the D7 fastcgi_drupal config, so it can override the new default D8+ one.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=builder /srv/www/vendor /srv/www/vendor
 COPY --from=builder /srv/www/composer.json /srv/www/composer.json
 COPY --from=builder /srv/www/composer.lock /srv/www/composer.lock
 COPY --from=builder /srv/www/composer.patches.json /srv/www/composer.patches.json
+COPY --from=builder /srv/www/docker/fastcgi_drupal.conf /etc/nginx/apps/drupal/fastcgi_drupal.conf
 COPY --from=builder /srv/www/docker/custom /etc/nginx/custom
 
 RUN  cd /srv/www/html/sites && \

--- a/docker/fastcgi_drupal.conf
+++ b/docker/fastcgi_drupal.conf
@@ -1,0 +1,43 @@
+#-*- mode: nginx; mode: flyspell-prog; ispell-local-dictionary: "american" -*-
+### fastcgi configuration for serving private files.
+## 1. Parameters.
+fastcgi_param QUERY_STRING q=$uri&$args;
+fastcgi_param REQUEST_METHOD $request_method;
+fastcgi_param CONTENT_TYPE $content_type;
+fastcgi_param CONTENT_LENGTH $content_length;
+
+fastcgi_param SCRIPT_NAME /index.php;
+fastcgi_param REQUEST_URI $request_uri;
+fastcgi_param DOCUMENT_URI $document_uri;
+fastcgi_param DOCUMENT_ROOT $document_root;
+fastcgi_param SERVER_PROTOCOL $server_protocol;
+
+fastcgi_param GATEWAY_INTERFACE CGI/1.1;
+fastcgi_param SERVER_SOFTWARE nginx/$nginx_version;
+
+fastcgi_param REMOTE_ADDR $remote_addr;
+fastcgi_param REMOTE_PORT $remote_port;
+fastcgi_param SERVER_ADDR $server_addr;
+fastcgi_param SERVER_PORT $server_port;
+fastcgi_param SERVER_NAME $server_name;
+## PHP only, required if PHP was built with --enable-force-cgi-redirect
+fastcgi_param REDIRECT_STATUS 200;
+fastcgi_param SCRIPT_FILENAME $document_root/index.php;
+## HTTPS 'on' parameter.  This requires Nginx version 1.1.11 or
+## later. The if_not_empty flag was introduced in 1.1.11.  See:
+## http://nginx.org/en/CHANGES. If using a version that doesn't
+## support this comment out the line below.
+fastcgi_param HTTPS $fastcgi_https if_not_empty;
+## For Nginx versions below 1.1.11 uncomment the line below after commenting out the above.
+#fastcgi_param HTTPS $fastcgi_https;
+
+## 2. Nginx FCGI specific directives.
+fastcgi_buffers 256 4k;
+fastcgi_intercept_errors on;
+## Allow 4 hrs - pass timeout responsibility to upstream.
+fastcgi_read_timeout 14400;
+fastcgi_index index.php;
+## Hide the X-Drupal-Cache header provided by Pressflow.
+fastcgi_hide_header 'X-Drupal-Cache';
+## Hide the Drupal 7 header X-Generator.
+fastcgi_hide_header 'X-Generator';


### PR DESCRIPTION
Refs: OPS-8977