### PR TITLE
fix: remove patch which no longer applies

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -56,9 +56,6 @@
         "User can create node without permission": "https://patch-diff.githubusercontent.com/raw/Gizra/og/pull/442.patch",
         "HR.info issue 839": "PATCHES/hrinfo-839.patch"
       },
-      "drupal/og_features": {
-        "Permission to 'edit own group features' only works if the user also has the 'administer group' permission": "https://www.drupal.org/files/2019515-og_features-group-permission.patch"
-      },
       "drupal/og_menu": {
         "Add i18n support": "https://www.drupal.org/files/issues/og_menu-i18n-2348821-12.patch",
         "Integrate with menu_target": "https://www.drupal.org/files/issues/og_menu-integrate-menu-target-2387975-3.patch"


### PR DESCRIPTION
Refs: updates

This patch was only added recently, but doesn't seem to apply now. Assuming that no group owners will make further edits anyway.

Discovered this while attempting to solve the failed build: https://github.com/UN-OCHA/hrinfo-site/actions/runs/5065892276/jobs/9095744573 , which might require further debugging.