### PR TITLE
fix: pin composer version till preserve-paths package is updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - cd $TRAVIS_BUILD_DIR
-  - composer self-update --2
+  - composer self-update 2.5.5
   - composer install
 
 script:


### PR DESCRIPTION
Refs: updates

Replaces the other changes tried in https://github.com/UN-OCHA/hrinfo-site/pull/1253 - though may have to remove the patch referred to in that issue too.