### PR TITLE
chore: don't commit contrib modules and themes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/login-action@v2.1.0
         with:
           registry: public.ecr.aws
-          username: ${{ secrets.ECR_AWS_ACCESS_KEY_I }}
+          username: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
         env:
           AWS_REGION: us-east-1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
-# Test stuff.
-/vendor
-/bin
+# Ignore configuration files that may contain sensitive information.
+html/sites/*/settings*.php
+
+# Ignore paths that contain user-generated content.
+html/sites/*/files
+html/sites/*/private
+
+# Ignore composer stuff.
+bin/
+vendor/
+
+# Never commit contrib modules or themes.
+html/sites/all/modules/contrib
+html/sites/all/themes/contrib


### PR DESCRIPTION
Refs: updates

As suggested in https://github.com/UN-OCHA/hrinfo-site/pull/1272 - the .gitignore file is the same as that for unocha-org https://github.com/UN-OCHA/unocha-org/blob/develop/.gitignore, but without the ckeditor exceptions.